### PR TITLE
[FEAT] 전역 예외 처리 및 에러 응답 추가

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.ppopi.ppopihouse.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/ppopi/ppopihouse/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.ppopi.ppopihouse.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse("UNAUTHORIZED", e.getMessage()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(
+            RuntimeException e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse("INTERNAL_SERVER_ERROR", e.getMessage()));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 전역 예외 처리를 위한 GlobalExceptionHandler 추가
- 공통 에러 응답 포맷을 위한 ErrorResponse 클래스 추가
- 인증 및 일반 예외 발생 시 일관된 응답 반환하도록 처리

## 🔧 주요 변경 사항

- IllegalArgumentException → 401 Unauthorized 처리
- RuntimeException → 500 Internal Server Error 처리
- 에러 응답을 code, message 형태로 통일

## ✅ 체크리스트

- [x] 잘못된 요청 시 에러 응답 정상 반환 확인
- [x] 카카오 토큰 검증 실패 시 401 응답 확인
- [x] 서버 내부 오류 발생 시 500 응답 확인

## 🔗 관련 이슈

Closes #6