### PR TITLE
다이어리 CRUD 기능 구현 및 펫 등록 API 의존성 수정

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/diary/controller/DiaryController.java
@@ -1,0 +1,84 @@
+package com.ppopi.ppopihouse.domain.diary.controller;
+
+import com.ppopi.ppopihouse.domain.diary.dto.DiaryRequestDto;
+import com.ppopi.ppopihouse.domain.diary.dto.DiaryResponseDto;
+import com.ppopi.ppopihouse.domain.diary.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    /**
+     * 1. 펫 리스트 요청 (특정 사용자의 펫 아이디, 이름, 색깔)
+     */
+    @GetMapping("/pets")
+    public ResponseEntity<List<DiaryResponseDto.PetSummary>> getPetList(
+            @RequestParam Long memberId) { // 파라미터 추가
+        return ResponseEntity.ok(diaryService.findPetSummaries(memberId));
+    }
+
+    /**
+     * 2. 월간 데이터 요청 (예: 2026년 3월 데이터 요청)
+     * 결과: 일자별 다이어리가 존재하는 색깔 리스트
+     */
+    @GetMapping("/monthly")
+    public ResponseEntity<List<DiaryResponseDto.MonthlyRecord>> getMonthlyRecords(
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(required = false) Long petId) { // 선택 파라미터 추가
+        return ResponseEntity.ok(diaryService.findMonthlyColors(year, month, petId));
+    }
+
+
+
+    /**
+     * 3. 일별 데이터 요청 (예: 2026-03-04 데이터 요청)
+     * 결과: 해당 일자의 다이어리 리스트
+     */
+    @GetMapping("/daily")
+    public ResponseEntity<List<DiaryResponseDto.DiaryDetail>> getDailyDiaries(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(required = false) Long petId) { // 선택 파라미터 추가
+        return ResponseEntity.ok(diaryService.findDiariesByDate(date, petId));
+    }
+
+    /**
+     * 4. 다이어리 추가 (펫ID, 메모, 체크리스트)
+     */
+    @PostMapping
+    public ResponseEntity<Void> addDiary(@RequestBody DiaryRequestDto.Create request) {
+        diaryService.saveDiary(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * 5. 특정 다이어리 수정 (다이어리 ID, 메모, 체크리스트)
+     */
+    @PutMapping("/{diaryId}")
+    public ResponseEntity<Void> updateDiary(
+            @PathVariable Long diaryId,
+            @RequestBody DiaryRequestDto.Update request) {
+        diaryService.updateDiary(diaryId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 6. 특정 다이어리 삭제 (다이어리 ID)
+     */
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<Void> deleteDiary(@PathVariable Long diaryId) {
+        diaryService.deleteDiary(diaryId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/diary/dto/DiaryRequestDto.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/diary/dto/DiaryRequestDto.java
@@ -1,0 +1,40 @@
+package com.ppopi.ppopihouse.domain.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class DiaryRequestDto {
+
+    /**
+     * 다이어리 추가 요청 (펫ID, 메모, 체크리스트)
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Create {
+        private Long petId;
+        private Long diagnosisId; // 진단 아이디 (진단 후 생성 시 필요)
+        private LocalDate entryDate; // 일자 (기본값 설정 가능)
+        private String memo;
+        private List<Integer> checkList;
+    }
+
+    /**
+     * 특정 다이어리 수정 요청 (메모, 체크리스트)
+     * 수정 시 diaryId는 보통 API 경로(Path Variable)로 받으므로 본문에서는 제외합니다.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Update {
+        private String memo;
+        private List<Integer> checkList;
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/diary/dto/DiaryResponseDto.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/diary/dto/DiaryResponseDto.java
@@ -1,0 +1,45 @@
+package com.ppopi.ppopihouse.domain.diary.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class DiaryResponseDto {
+
+
+
+    /**
+     * 펫 리스트 응답용 (펫 아이디, 이름, 색깔)
+     */
+    @Getter
+    @Builder
+    public static class MonthlyRecord {
+        private LocalDate date;
+        private List<PetSummary> pets; // Integer 대신 객체 리스트로 변경
+    }
+
+    @Getter
+    @Builder
+    public static class PetSummary {
+        private Long petId;
+        private String name;
+        private int color;
+    }
+
+    /**
+     * 일별 다이어리 리스트 및 상세 응답용
+     */
+    @Getter
+    @Builder
+    public static class DiaryDetail {
+        private Long diaryId;
+        private Long petId;
+        private Long diagnosisId;
+        private LocalDate entryDate;
+        private String memo;
+        private List<Integer> checkList; // 체크리스트 항목들
+    }
+
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/diary/entity/DiaryEntry.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/diary/entity/DiaryEntry.java
@@ -1,0 +1,63 @@
+package com.ppopi.ppopihouse.domain.diary.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자 보안 강화
+@Table(name = "diary_entry")
+public class DiaryEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long diaryId;
+
+    private Long petId;
+
+    private Long diagnosisId; // AI 진단 결과와 연동
+
+    private LocalDate entryDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    /**
+     * 체크리스트 항목들
+     * final을 붙여 참조가 바뀌지 않도록 설정 (노란 줄 해결)
+     */
+    @ElementCollection
+    @CollectionTable(name = "diary_entry_check", joinColumns = @JoinColumn(name = "diary_id"))
+    @Column(name = "check_id")
+    private final List<Integer> checkIds = new ArrayList<>();
+
+    @Builder
+    public DiaryEntry(Long petId, Long diagnosisId, LocalDate entryDate, String memo, List<Integer> checkIds) {
+        this.petId = petId;
+        this.diagnosisId = diagnosisId;
+        this.entryDate = entryDate;
+        this.memo = memo;
+        if (checkIds != null) {
+            this.checkIds.addAll(checkIds);
+        }
+    }
+
+    /**
+     * 다이어리 수정 로직 (Setter 대신 도메인 메서드 사용)
+     */
+    public void updateDiary(String memo, List<Integer> checkIds) {
+        this.memo = memo;
+        // 컬렉션은 주소를 바꾸는 것(this.checkIds = checkIds)보다 내용을 비우고 채우는 것이 안전함
+        this.checkIds.clear();
+        if (checkIds != null) {
+            this.checkIds.addAll(checkIds);
+        }
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/diary/repository/DiaryRepository.java
@@ -1,0 +1,33 @@
+package com.ppopi.ppopihouse.domain.diary.repository;
+
+import com.ppopi.ppopihouse.domain.diary.entity.DiaryEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<DiaryEntry, Long> {
+
+    /**
+     * 특정 날짜의 모든 다이어리 항목을 조회합니다. (일간 요청용)
+     */
+    List<DiaryEntry> findAllByEntryDate(LocalDate entryDate);
+
+    /**
+     * 특정 기간(시작일 ~ 종료일) 사이의 모든 다이어리 항목을 조회합니다. (월간 요청용)
+     * 이 데이터를 기반으로 Service 레이어에서 일자별 색깔 리스트를 가공합니다.
+     */
+    List<DiaryEntry> findAllByEntryDateBetween(LocalDate startDate, LocalDate endDate);
+
+    /**
+     * 특정 펫의 모든 다이어리 항목을 조회합니다.
+     */
+    List<DiaryEntry> findAllByPetId(Long petId);
+    // 특정 펫의 날짜 범위 조회 (필터링용)
+    List<DiaryEntry> findAllByPetIdAndEntryDateBetween(Long petId, LocalDate start, LocalDate end);
+
+    // 특정 펫의 특정 날짜 조회 (필터링용)
+    List<DiaryEntry> findAllByPetIdAndEntryDate(Long petId, LocalDate date);
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/diary/service/DiaryService.java
@@ -1,0 +1,134 @@
+package com.ppopi.ppopihouse.domain.diary.service;
+
+import com.ppopi.ppopihouse.domain.diary.dto.DiaryRequestDto;
+import com.ppopi.ppopihouse.domain.diary.dto.DiaryResponseDto;
+import com.ppopi.ppopihouse.domain.diary.entity.DiaryEntry;
+import com.ppopi.ppopihouse.domain.diary.repository.DiaryRepository;
+import com.ppopi.ppopihouse.domain.pet.entity.Pet;
+import com.ppopi.ppopihouse.domain.pet.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final PetRepository petRepository;
+
+    /**
+     * 1. 특정 사용자의 펫 리스트 조회 (ID, 이름, 색깔)
+     */
+    public List<DiaryResponseDto.PetSummary> findPetSummaries(Long memberId) {
+        return petRepository.findAllByMemberId(memberId).stream()
+                .map(pet -> DiaryResponseDto.PetSummary.builder()
+                        .petId(pet.getPetId())
+                        .name(pet.getName())
+                        .color(pet.getColor())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 2. 월간 데이터 조회 (일자별 다이어리 존재 펫들의 색깔 리스트)
+     */
+    public List<DiaryResponseDto.MonthlyRecord> findMonthlyColors(int year, int month, Long petId) {
+        LocalDate start = YearMonth.of(year, month).atDay(1);
+        LocalDate end = YearMonth.of(year, month).atEndOfMonth();
+
+        List<DiaryEntry> entries = (petId != null)
+                ? diaryRepository.findAllByPetIdAndEntryDateBetween(petId, start, end)
+                : diaryRepository.findAllByEntryDateBetween(start, end);
+
+        Map<Long, Pet> petMap = petRepository.findAll().stream()
+                .collect(Collectors.toMap(Pet::getPetId, pet -> pet));
+
+        return entries.stream()
+                .collect(Collectors.groupingBy(DiaryEntry::getEntryDate))
+                .entrySet().stream()
+                .map(entry -> DiaryResponseDto.MonthlyRecord.builder()
+                        .date(entry.getKey())
+                        .pets(entry.getValue().stream()
+                                .map(d -> {
+                                    Pet pet = petMap.get(d.getPetId());
+                                    return DiaryResponseDto.PetSummary.builder()
+                                            .petId(d.getPetId())
+                                            .name(pet != null ? pet.getName() : "Unknown")
+                                            .color(pet != null ? pet.getColor() : 0)
+                                            .build();
+                                })
+                                .distinct()
+                                .collect(Collectors.toList()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 3. 일별 다이어리 리스트 조회
+     */
+    public List<DiaryResponseDto.DiaryDetail> findDiariesByDate(LocalDate date, Long petId) {
+        List<DiaryEntry> entries = (petId != null)
+                ? diaryRepository.findAllByPetIdAndEntryDate(petId, date)
+                : diaryRepository.findAllByEntryDate(date);
+
+        return entries.stream().map(this::convertToDetailDto).collect(Collectors.toList());
+    }
+
+    /**
+     * 4. 다이어리 추가
+     */
+    @Transactional
+    public void saveDiary(DiaryRequestDto.Create request) {
+        DiaryEntry diaryEntry = DiaryEntry.builder()
+                .petId(request.getPetId())
+                .diagnosisId(request.getDiagnosisId())
+                .entryDate(request.getEntryDate())
+                .memo(request.getMemo())
+                .checkIds(request.getCheckList())
+                .build();
+        diaryRepository.save(diaryEntry);
+    }
+
+    /**
+     * 5. 다이어리 수정
+     */
+    @Transactional
+    public void updateDiary(Long diaryId, DiaryRequestDto.Update request) {
+        DiaryEntry diaryEntry = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 다이어리가 존재하지 않습니다. ID: " + diaryId));
+
+        diaryEntry.updateDiary(request.getMemo(), request.getCheckList());
+    }
+
+    /**
+     * 6. 다이어리 삭제
+     */
+    @Transactional
+    public void deleteDiary(Long diaryId) {
+        diaryRepository.deleteById(diaryId);
+    }
+
+    /**
+     * 내부 변환 로직: Entity -> DTO
+     */
+    private DiaryResponseDto.DiaryDetail convertToDetailDto(DiaryEntry entry) {
+        return DiaryResponseDto.DiaryDetail.builder()
+                .diaryId(entry.getDiaryId())
+                .petId(entry.getPetId())
+                .diagnosisId(entry.getDiagnosisId())
+                .entryDate(entry.getEntryDate())
+                .memo(entry.getMemo())
+                // 정수 리스트(checkIds)를 DTO의 리스트로 즉시 변환 (참조 끊기 위해 새 리스트 생성)
+                .checkList(new ArrayList<>(entry.getCheckIds()))
+                .build();
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/pet/controller/PetController.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/pet/controller/PetController.java
@@ -1,0 +1,28 @@
+package com.ppopi.ppopihouse.domain.pet.controller;
+
+import com.ppopi.ppopihouse.domain.pet.dto.PetRegisterRequestDto;
+import com.ppopi.ppopihouse.domain.pet.service.PetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Pet API", description = "반려동물 등록 및 관리")
+@RestController
+@RequestMapping("/api/pets")
+@RequiredArgsConstructor
+public class PetController {
+
+    private final PetService petService;
+
+    @PostMapping
+    @Operation(summary = "반려동물 등록", description = "반려동물 정보를 입력받아 DB에 저장합니다.")
+    public ResponseEntity<String> registerPet(@RequestBody PetRegisterRequestDto requestDto) {
+        // 서비스 호출 및 PK 반환
+        Long savedId = petService.registerPet(requestDto);
+
+        // 성공 시 200 OK와 저장된 ID 반환
+        return ResponseEntity.ok("Successfully registered. ID: " + savedId);
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/pet/dto/PetRegisterRequestDto.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/pet/dto/PetRegisterRequestDto.java
@@ -1,0 +1,16 @@
+package com.ppopi.ppopihouse.domain.pet.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PetRegisterRequestDto {
+    private String name;
+    private String species;
+    private String breed;
+    private char gender;
+    private int age;
+    private int color;
+    private Long memberId; // 현재 로그인된 회원 정보가 넘어온다고 가정
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/pet/entity/Pet.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/pet/entity/Pet.java
@@ -1,0 +1,36 @@
+package com.ppopi.ppopihouse.domain.pet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+@Entity // DB 테이블과 매핑되는 클래스임을 선언
+@Getter
+@NoArgsConstructor
+@Table(name = "pet") // 실제 DB 테이블 이름
+public class Pet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long petId;
+
+    private Long memberId;
+    private String name;
+    private String species;
+    private String breed;
+    private int birthYear;
+    private char sex;
+    private int color;
+
+    // 생성자 (나중에 Service에서 사용)
+    public Pet(Long memberId, String name, String species, String breed, int birthYear, char sex, int color) {
+        this.memberId = memberId;
+        this.name = name;
+        this.species = species;
+        this.breed = breed;
+        this.birthYear = birthYear;
+        this.sex = sex;
+        this.color = color;
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/pet/repository/PetRepository.java
@@ -1,0 +1,16 @@
+package com.ppopi.ppopihouse.domain.pet.repository;
+
+// 1. 컬렉션 프레임워크의 List 인터페이스 (필수)
+import java.util.List;
+
+// 2. 관리 대상인 Pet 엔티티 (필수)
+import com.ppopi.ppopihouse.domain.pet.entity.Pet;
+
+// 3. 스프링 데이터 JPA 관련 (이미 존재할 가능성이 높음)
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+@Repository
+public interface PetRepository extends JpaRepository<Pet, Long> {
+    // 기본 CRUD는 JpaRepository가 다 알아서 해줍니다.
+    List<Pet> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/ppopi/ppopihouse/domain/pet/service/PetService.java
+++ b/src/main/java/com/ppopi/ppopihouse/domain/pet/service/PetService.java
@@ -1,0 +1,34 @@
+package com.ppopi.ppopihouse.domain.pet.service;
+
+import com.ppopi.ppopihouse.domain.pet.dto.PetRegisterRequestDto;
+import com.ppopi.ppopihouse.domain.pet.entity.Pet;
+import com.ppopi.ppopihouse.domain.pet.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PetService {
+
+    private final PetRepository petRepository;
+
+    public Long registerPet(PetRegisterRequestDto requestDto) {
+        // 나이를 바탕으로 출생연도 계산 로직 (2026년 기준)
+        int birthYear = LocalDate.now().getYear() - requestDto.getAge();
+
+        Pet pet = new Pet(
+                requestDto.getMemberId(),
+                requestDto.getName(),
+                requestDto.getSpecies(),
+                requestDto.getBreed(),
+                birthYear,
+                requestDto.getGender(),
+                requestDto.getColor()
+        );
+
+        return petRepository.save(pet).getPetId();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: local # local 프로파일을 사용


### PR DESCRIPTION
- 다이어리 등록, 수정, 삭제, 상세 조회 기능 추가
- 월간 및 일별 다이어리 조회 API 추가
- 펫 등록 API 의존성을 기존 프로젝트 규격에 맞춰 재조정
- 일별/월간 조회 시 펫 ID 기반 필터링 파라미터 적용

## 📝 작업 내용

-

---

## 🔥 변경 사항

-

---

## 📸 스크린샷 (선택)

<!-- API 테스트 결과 / Swagger 캡처 등 -->

---

## ✅ 체크리스트

- [x] 기능 정상 동작 확인
- [x] 로컬 테스트 완료
- [x] Swagger 테스트 완료
- [ ] 코드 리뷰 반영 완료

---

## 🔗 관련 이슈

Closes #

---

## 💬 기타 참고사항

-