### PR TITLE
[FEAT] 증상 반환 리스트

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/controller/SymptomController.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/controller/SymptomController.java
@@ -1,2 +1,24 @@
-package com.ppopi.ppopihouse.diagnosis.controller;public class SymptomController {
+package com.ppopi.ppopihouse.diagnosis.controller;
+
+import com.ppopi.ppopihouse.diagnosis.dto.response.SymptomResponse;
+import com.ppopi.ppopihouse.diagnosis.service.SymptomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/symptoms")
+@RequiredArgsConstructor
+public class SymptomController {
+
+    private final SymptomService symptomService;
+
+    @GetMapping
+    public List<SymptomResponse> getSymptoms() {
+        return symptomService.getSymptoms();
+    }
+
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/domain/EyeSymptom.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/domain/EyeSymptom.java
@@ -2,6 +2,10 @@ package com.ppopi.ppopihouse.diagnosis.domain;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Getter
 public enum EyeSymptom {
 
@@ -21,13 +25,16 @@ public enum EyeSymptom {
         this.name = name;
     }
 
+    private static final Map<Long, EyeSymptom> MAP =
+            Arrays.stream(values())
+                    .collect(Collectors.toMap(EyeSymptom::getId, s -> s));
+
     public static EyeSymptom fromId(Long id) {
-        for (EyeSymptom symptom : values()) {
-            if (symptom.id.equals(id)) {
-                return symptom;
-            }
+        EyeSymptom symptom = MAP.get(id);
+        if (symptom == null) {
+            throw new IllegalArgumentException("존재하지 않는 증상입니다.");
         }
-        throw new IllegalArgumentException("존재하지 않는 증상입니다.");
+        return symptom;
     }
 
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/domain/EyeSymptom.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/domain/EyeSymptom.java
@@ -18,11 +18,11 @@ public enum EyeSymptom {
     PAIN_SUSPECTED(7L, "통증 의심");
 
     private final Long id;
-    private final String name;
+    private final String description;
 
-    EyeSymptom(Long id, String name) {
+    EyeSymptom(Long id, String description) {
         this.id = id;
-        this.name = name;
+        this.description = description;
     }
 
     private static final Map<Long, EyeSymptom> MAP =

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/domain/Symptom.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/domain/Symptom.java
@@ -18,4 +18,5 @@ public class Symptom {
 
     @Column(nullable = false)
     private String name;
+
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/SymptomResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/SymptomResponse.java
@@ -12,6 +12,6 @@ public class SymptomResponse {
     private String name;
 
     public static SymptomResponse from(EyeSymptom symptom) {
-        return new SymptomResponse(symptom.getId(), symptom.getName());
+        return new SymptomResponse(symptom.getId(), symptom.getDescription());
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/SymptomResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/SymptomResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class SymptomResponse {
 
     private Long id;
-    private String name;
+    private String description;
 
     public static SymptomResponse from(EyeSymptom symptom) {
         return new SymptomResponse(symptom.getId(), symptom.getDescription());

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -48,7 +48,7 @@ public class DiagnosisService {
 
         List<String> symptoms = symptomIds.stream()
                 .map(EyeSymptom::fromId)
-                .map(EyeSymptom::getName)
+                .map(EyeSymptom::getDescription)
                 .toList();
 
         AiDiagnosisRequest aiRequest = new AiDiagnosisRequest(

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/SymptomService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/SymptomService.java
@@ -1,0 +1,19 @@
+package com.ppopi.ppopihouse.diagnosis.service;
+
+import com.ppopi.ppopihouse.diagnosis.domain.EyeSymptom;
+import com.ppopi.ppopihouse.diagnosis.dto.response.SymptomResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class SymptomService {
+
+    public List<SymptomResponse> getSymptoms() {
+        return Arrays.stream(EyeSymptom.values())
+                .map(SymptomResponse::from)
+                .toList();
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용

- EyeSymptom Enum 기반 증상 리스트 조회 API 구현
- SymptomResponse DTO 생성 및 Enum → DTO 변환 로직 구현
- GET /api/symptoms 엔드포인트 추가
- 클라이언트 증상 선택 화면에서 사용할 데이터 제공

---

## ✅ 체크리스트

- [x] 기능 정상 동작 확인
- [x] 로컬 테스트 완료
- [x] Swagger 테스트 완료
- [ ] 코드 리뷰 반영 완료

---

## 🔗 관련 이슈

Closes #24

---