### PR TITLE
feat(security): swagger에 Authorize 버튼 추가

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/config/SwaggerConfig.java
@@ -1,16 +1,32 @@
 package com.ppopi.ppopihouse.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
+    @Bean
     public OpenAPI ppopiHouseOpenAPI() {
+        String schemeName = "JWT";
+
         return new OpenAPI()
                 .info(new Info()
                         .title("뽀삐의 집 API")
                         .description("뽀삐의 집 캡스톤 프로젝트 API 문서")
-                        .version("v1.0.0"));
+                        .version("v1.0.0"))
+                .components(new Components()
+                        .addSecuritySchemes(schemeName,
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList(schemeName));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: ppopihouse
+
+  profiles:
+    active: local
+
+  sql:
+    init:
+      mode: always
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs


### PR DESCRIPTION
## 📝 작업 내용

- Swagger에서 JWT 인증 테스트 가능하도록 Authorize 버튼 추가
- Spring Security + JWT 환경에서 Swagger 요청 시 토큰 전달 가능하도록 설정

---

## 🔥 변경 사항

- Swagger Security Scheme 설정 추가 (Bearer JWT)
- Swagger UI Authorization 입력 기능 활성화
- 인증 필요한 API 테스트 가능하도록 구성

---

## ✅ 체크리스트

- [x] 기능 정상 동작 확인
- [x] 로컬 테스트 완료
- [x] Swagger 테스트 완료

---

## 🔗 관련 이슈

Closes #3 

---

## 💬 기타 참고사항

- Swagger에서 `Bearer {JWT}` 형식으로 토큰 입력
- 이후 인증 API 테스트 시 별도 헤더 설정 없이 사용 가능