### PR TITLE
feat(diagnosis, genetic-disease): 홈 화면 유전병 조회 및 당일 진단 결과 조회 API 구현

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/controller/DiagnosisController.java
@@ -1,17 +1,20 @@
 package com.ppopi.ppopihouse.diagnosis.controller;
 
 import com.ppopi.ppopihouse.diagnosis.dto.response.DiagnosisResponse;
+import com.ppopi.ppopihouse.diagnosis.dto.response.RecentDiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.service.DiagnosisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/diagnoses")
+@RequestMapping("/diagnoses")
 public class DiagnosisController {
 
     private final DiagnosisService diagnosisService;
@@ -23,5 +26,14 @@ public class DiagnosisController {
             @RequestParam List<Long> symptomIds
     ) {
         return diagnosisService.diagnose(petId, image, symptomIds);
+    }
+
+    @GetMapping("/today")
+    public RecentDiagnosisResponse getTodayDiagnosis(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam Long petId,
+            @RequestParam LocalDate date
+    ) {
+        return diagnosisService.getTodayDiagnosis(memberId, petId, date);
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/RecentDiagnosisResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/RecentDiagnosisResponse.java
@@ -1,0 +1,50 @@
+package com.ppopi.ppopihouse.diagnosis.dto.response;
+
+import com.ppopi.ppopihouse.diagnosis.domain.Diagnosis;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RecentDiagnosisResponse {
+
+    private boolean hasDiagnosis;
+
+    private Long diagnosisId;
+    private String imageUrl;
+
+    private Long diseaseId;
+    private String diseaseName;
+
+    private String triageKey;
+    private float triageConfidence;
+
+    private String guideMsg;
+    private String guideWarn;
+    private String guideAction;
+
+    public static RecentDiagnosisResponse empty() {
+        return new RecentDiagnosisResponse(
+                false,
+                null, null,
+                null, null,
+                null, 0,
+                null, null, null
+        );
+    }
+
+    public static RecentDiagnosisResponse from(Diagnosis d) {
+        return new RecentDiagnosisResponse(
+                true,
+                d.getDiagnosisId(),
+                d.getImageUrl(),
+                d.getDisease().getDiseaseId(),
+                d.getDisease().getDiseaseName(),
+                d.getTriageKey(),
+                d.getTriageConfidence(),
+                d.getGuideMsg(),
+                d.getGuideWarn(),
+                d.getGuideAction()
+        );
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/DiagnosisRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/DiagnosisRepository.java
@@ -3,5 +3,13 @@ package com.ppopi.ppopihouse.diagnosis.repository;
 import com.ppopi.ppopihouse.diagnosis.domain.Diagnosis;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface DiagnosisRepository extends JpaRepository<Diagnosis, Long> {
+
+    Optional<Diagnosis> findTopByPet_PetIdAndDiagnosisDateOrderByDiagnosisIdDesc(
+            Long petId,
+            LocalDate diagnosisDate
+    );
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -6,6 +6,7 @@ import com.ppopi.ppopihouse.diagnosis.dto.external.AiDiagnosisRequest;
 import com.ppopi.ppopihouse.diagnosis.dto.external.AiDiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.dto.external.ImageValidationResponse;
 import com.ppopi.ppopihouse.diagnosis.dto.response.DiagnosisResponse;
+import com.ppopi.ppopihouse.diagnosis.dto.response.RecentDiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.repository.DiagnosisRepository;
 import com.ppopi.ppopihouse.global.infra.cloud.ImageStorageService;
 import com.ppopi.ppopihouse.pet.domain.Pet;
@@ -82,6 +83,21 @@ public class DiagnosisService {
                 aiResponse.getGuidanceMessage(),
                 aiResponse.getGuidanceAction()
         );
+    }
+
+    public RecentDiagnosisResponse getTodayDiagnosis(Long memberId, Long petId, LocalDate date) {
+
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+
+        if (!pet.getMember().getMemberId().equals(memberId)) {
+            throw new SecurityException("해당 반려동물에 대한 접근 권한이 없습니다.");
+        }
+
+        return diagnosisRepository
+                .findTopByPet_PetIdAndDiagnosisDateOrderByDiagnosisIdDesc(petId, date)
+                .map(RecentDiagnosisResponse::from)
+                .orElseGet(RecentDiagnosisResponse::empty);
     }
 
     private int calculateAge(int birthYear) {

--- a/src/main/java/com/ppopi/ppopihouse/genetic/controller/GeneticDiseaseController.java
+++ b/src/main/java/com/ppopi/ppopihouse/genetic/controller/GeneticDiseaseController.java
@@ -1,0 +1,28 @@
+package com.ppopi.ppopihouse.genetic.controller;
+
+import com.ppopi.ppopihouse.genetic.dto.response.GeneticDiseaseResponse;
+import com.ppopi.ppopihouse.genetic.service.GeneticDiseaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/genetic-diseases")
+@RequiredArgsConstructor
+public class GeneticDiseaseController {
+
+    private final GeneticDiseaseService geneticDiseaseService;
+
+    @GetMapping("/random")
+    public List<GeneticDiseaseResponse> getRandomDiseases() {
+        return geneticDiseaseService.getRandomDiseases();
+    }
+
+    @GetMapping("/search")
+    public List<GeneticDiseaseResponse> searchDiseases(
+            @RequestParam String keyword
+    ) {
+        return geneticDiseaseService.searchDiseases(keyword);
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/genetic/domain/GeneticDisease.java
+++ b/src/main/java/com/ppopi/ppopihouse/genetic/domain/GeneticDisease.java
@@ -1,0 +1,27 @@
+package com.ppopi.ppopihouse.genetic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "genetic_disease")
+public class GeneticDisease {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "genetic_disease_id")
+    private Long geneticDiseaseId;
+
+    @Column(nullable = false)
+    private String breed;
+
+    @Column(nullable = false)
+    private String diseaseName;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+}

--- a/src/main/java/com/ppopi/ppopihouse/genetic/dto/response/GeneticDiseaseResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/genetic/dto/response/GeneticDiseaseResponse.java
@@ -1,0 +1,24 @@
+package com.ppopi.ppopihouse.genetic.dto.response;
+
+import com.ppopi.ppopihouse.genetic.domain.GeneticDisease;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneticDiseaseResponse {
+
+    private Long geneticDiseaseId;
+    private String breed;
+    private String diseaseName;
+    private String description;
+
+    public static GeneticDiseaseResponse from(GeneticDisease disease) {
+        return new GeneticDiseaseResponse(
+                disease.getGeneticDiseaseId(),
+                disease.getBreed(),
+                disease.getDiseaseName(),
+                disease.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/genetic/repository/GeneticDiseaseRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/genetic/repository/GeneticDiseaseRepository.java
@@ -1,0 +1,20 @@
+package com.ppopi.ppopihouse.genetic.repository;
+
+import com.ppopi.ppopihouse.genetic.domain.GeneticDisease;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface GeneticDiseaseRepository extends JpaRepository<GeneticDisease, Long> {
+
+    @Query("""
+    SELECT g
+    FROM GeneticDisease g
+    WHERE LOWER(g.breed) LIKE LOWER(CONCAT('%', :keyword, '%'))
+       OR LOWER(g.diseaseName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+       OR LOWER(g.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
+""")
+    List<GeneticDisease> searchByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/ppopi/ppopihouse/genetic/service/GeneticDiseaseService.java
+++ b/src/main/java/com/ppopi/ppopihouse/genetic/service/GeneticDiseaseService.java
@@ -1,0 +1,48 @@
+package com.ppopi.ppopihouse.genetic.service;
+
+import com.ppopi.ppopihouse.genetic.domain.GeneticDisease;
+import com.ppopi.ppopihouse.genetic.dto.response.GeneticDiseaseResponse;
+import com.ppopi.ppopihouse.genetic.repository.GeneticDiseaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GeneticDiseaseService {
+
+    private static final int DEFAULT_LIMIT = 3;
+
+    private final GeneticDiseaseRepository geneticDiseaseRepository;
+
+    public List<GeneticDiseaseResponse> getRandomDiseases() {
+        List<GeneticDisease> diseases = geneticDiseaseRepository.findAll();
+
+        if (diseases.isEmpty()) {
+            return null;
+        }
+
+        Collections.shuffle(diseases);
+
+        return diseases.stream()
+                .limit(DEFAULT_LIMIT)
+                .map(GeneticDiseaseResponse::from)
+                .toList();
+    }
+
+    public List<GeneticDiseaseResponse> searchDiseases(String keyword) {
+        List<GeneticDisease> diseases =
+                geneticDiseaseRepository.searchByKeyword(keyword, PageRequest.of(0, 3));
+
+        if (diseases.isEmpty()) {
+            return null;
+        }
+
+        return diseases.stream()
+                .map(GeneticDiseaseResponse::from)
+                .toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 server:
   port: 8080
 
@@ -22,8 +21,3 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v3/api-docs
-=======
-spring:
-  profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local}
->>>>>>> b9a705a (feat(jwt, security): jwt security 추가)


### PR DESCRIPTION
## 📝 작업 내용

- 홈 화면 유전병 조회 API 구현
- 홈 화면 당일 진단 결과 조회 API 구현

---

## 🔥 변경 사항

- 유전병 검색 API 추가 (키워드 기반 통합 검색: breed / disease / description)
- 유전병 랜덤 조회 기능 구현 (최대 3개 반환)
- 당일 진단 결과 조회 API 구현
  - 해당 날짜 진단 결과 존재 시 → 결과 반환
  - 없을 경우 → hasDiagnosis=false 반환
- DiagnosisResponse DTO 엔티티 필드 기준으로 정리
- MySQL / PostgreSQL 호환성 고려하여 쿼리 수정

---

## 📸 스크린샷 (선택)

<!-- Swagger 테스트 결과 첨부 -->

---

## ✅ 체크리스트

- [x] 기능 정상 동작 확인
- [x] 로컬 테스트 완료
- [x] Swagger 테스트 완료
- [ ] 코드 리뷰 반영 완료

---

## 🔗 관련 이슈

Closes #22 

---

## 💬 기타 참고사항

- 현재 pet API 미구현으로 인해 테스트용 데이터로 검증 진행