### PR TITLE
[FIX] permitAll 엔드포인트 수정

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**",
+                                "/auth/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**"


### PR DESCRIPTION
## 📝 작업 내용

- Spring Security permitAll 경로 누락으로 인한 로그인 403 문제 수정
- `/auth/**` 경로 추가하여 인증 없이 접근 가능하도록 설정

---

## 🔥 변경 사항

- SecurityConfig
  - `/auth/**` permitAll 추가
  - 기존 `/api/auth/**`와 경로 불일치 문제 해결

---

## 📸 스크린샷 

<img width="707" height="313" alt="스크린샷 2026-05-04 오후 12 00 10" src="https://github.com/user-attachments/assets/abe86136-6ea7-4d20-aeef-7ec08ed158e2" />

---

## ✅ 체크리스트

- [x] 기능 정상 동작 확인
- [x] 로컬 테스트 완료
- [x] Swagger 테스트 완료

---

## 💬 기타 참고사항

- 로그인 API URL(`/auth/**`)과 Security 설정 경로 불일치로 인해 발생한 문제