### PR TITLE
feat(diagnosis): 안구 이미지 기반 진단 API 구현

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/controller/DiagnosisController.java
@@ -6,6 +6,7 @@ import com.ppopi.ppopihouse.diagnosis.service.DiagnosisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -41,10 +42,10 @@ public class DiagnosisController {
             @RequestParam Long petId,
 
             @Parameter(description = "진단에 사용할 반려동물 이미지 파일")
-            @RequestPart("image") MultipartFile image,
+            @RequestParam("image") MultipartFile image,
 
             @Parameter(description = "선택한 증상 ID 목록", example = "1,2,3")
-            @RequestParam List<Long> symptomIds
+            @RequestParam(required = false) List<Long> symptomIds
     ) {
         return diagnosisService.diagnose(petId, image, symptomIds);
     }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/DiagnosisResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/dto/response/DiagnosisResponse.java
@@ -7,11 +7,23 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DiagnosisResponse {
 
-    private String diseaseName;
-    private String triage;
-    private float confidence;
-    private String affectedArea;
-    private String description;
-    private String action;
+    private Summary summary;
+    private ResultCard resultCard;
 
+    @Getter
+    @AllArgsConstructor
+    public static class Summary {
+        private String status;
+        private String diseaseName;
+        private int confidence;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ResultCard {
+        private String title;
+        private String description;
+        private String guideTitle;
+        private String guideMessage;
+    }
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
@@ -1,0 +1,14 @@
+package com.ppopi.ppopihouse.diagnosis.repository;
+
+import com.ppopi.ppopihouse.diagnosis.domain.EyeDiseaseCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EyeDiseaseCodeRepository extends JpaRepository<EyeDiseaseCode, Long> {
+
+    Optional<EyeDiseaseCode> findByDiseaseNameAndInputSpecies(
+            String diseaseName,
+            String inputSpecies
+    );
+}

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -1,6 +1,7 @@
 package com.ppopi.ppopihouse.diagnosis.service;
 
 import com.ppopi.ppopihouse.diagnosis.domain.Diagnosis;
+import com.ppopi.ppopihouse.diagnosis.domain.EyeDiseaseCode;
 import com.ppopi.ppopihouse.diagnosis.domain.EyeSymptom;
 import com.ppopi.ppopihouse.diagnosis.dto.external.AiDiagnosisRequest;
 import com.ppopi.ppopihouse.diagnosis.dto.external.AiDiagnosisResponse;
@@ -8,6 +9,7 @@ import com.ppopi.ppopihouse.diagnosis.dto.external.ImageValidationResponse;
 import com.ppopi.ppopihouse.diagnosis.dto.response.DiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.dto.response.RecentDiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.repository.DiagnosisRepository;
+import com.ppopi.ppopihouse.diagnosis.repository.EyeDiseaseCodeRepository;
 import com.ppopi.ppopihouse.global.infra.cloud.ImageStorageService;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
@@ -25,6 +27,7 @@ public class DiagnosisService {
 
     private final PetRepository petRepository;
     private final DiagnosisRepository diagnosisRepository;
+    private final EyeDiseaseCodeRepository eyeDiseaseCodeRepository;
     private final ImageValidationClient imageValidationClient;
     private final ImageStorageService imageStorageService;
     private final AiDiagnosisClient aiDiagnosisClient;
@@ -47,7 +50,9 @@ public class DiagnosisService {
 
         String imageUrl = imageStorageService.upload(image);
 
-        List<String> symptoms = symptomIds.stream()
+        List<String> symptoms = symptomIds == null
+                ? List.of()
+                : symptomIds.stream()
                 .map(EyeSymptom::fromId)
                 .map(EyeSymptom::getDescription)
                 .toList();
@@ -63,12 +68,24 @@ public class DiagnosisService {
 
         AiDiagnosisResponse aiResponse = aiDiagnosisClient.diagnose(aiRequest);
 
+        String diseaseName = normalizeDiseaseName(aiResponse.getDisease());
+        String species = normalizeSpecies(pet.getSpecies());
+
+        EyeDiseaseCode disease = eyeDiseaseCodeRepository
+                .findByDiseaseNameAndInputSpecies(diseaseName, species)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "등록되지 않은 질병 코드입니다. disease=" + diseaseName + ", species=" + species
+                ));
+
         Diagnosis diagnosis = new Diagnosis();
         diagnosis.setPet(pet);
         diagnosis.setDiagnosisDate(LocalDate.now());
         diagnosis.setImageUrl(imageUrl);
+        diagnosis.setDisease(disease);
+
         diagnosis.setTriageKey(aiResponse.getTriage());
         diagnosis.setTriageConfidence(aiResponse.getTriageConfidence());
+
         diagnosis.setGuideMsg(aiResponse.getGuidanceMessage());
         diagnosis.setGuideAction(aiResponse.getGuidanceAction());
         diagnosis.setGuideWarn(aiResponse.getGuidanceWarning());
@@ -76,12 +93,17 @@ public class DiagnosisService {
         diagnosisRepository.save(diagnosis);
 
         return new DiagnosisResponse(
-                aiResponse.getDisease(),
-                aiResponse.getTriage(),
-                aiResponse.getTriageConfidence(),
-                aiResponse.getFamilyLabel(),
-                aiResponse.getGuidanceMessage(),
-                aiResponse.getGuidanceAction()
+                new DiagnosisResponse.Summary(
+                        formatStatus(aiResponse.getTriage()),
+                        formatDiseaseTitle(aiResponse.getDisease(), aiResponse.getFamilyLabel()),
+                        formatConfidence(aiResponse.getTriageConfidence())
+                ),
+                new DiagnosisResponse.ResultCard(
+                        formatDescriptionTitle(aiResponse.getDisease()),
+                        aiResponse.getGuidanceMessage(),
+                        formatGuideTitle(aiResponse.getTriage()),
+                        aiResponse.getGuidanceAction()
+                )
         );
     }
 
@@ -102,5 +124,80 @@ public class DiagnosisService {
 
     private int calculateAge(int birthYear) {
         return Year.now().getValue() - birthYear;
+    }
+
+    private String formatGuideTitle(String triage) {
+        if (triage == null) return "진료 권장";
+
+        return switch (triage.toLowerCase()) {
+            case "normal" -> "정상 안구입니다";
+            case "soon" -> "일주일 내 내원 권장";
+            case "urgent" -> "24시간 이내 내원 권장";
+            case "emergency" -> "즉시 응급 진료 권장";
+            default -> "진료 권장";
+        };
+    }
+
+    private String formatStatus(String triage) {
+        if (triage == null) return "Unknown";
+
+        return switch (triage.toLowerCase()) {
+            case "normal" -> "Normal";
+            case "soon" -> "Soon";
+            case "urgent" -> "Urgent";
+            case "emergency" -> "Emergency";
+            default -> triage;
+        };
+    }
+
+    private String formatDiseaseTitle(String diseaseName, String familyLabel) {
+        if ("정상".equals(diseaseName)) {
+            return "정상";
+        }
+
+        String area = switch (familyLabel) {
+            case "cornea" -> "각막";
+            case "conjunctiva" -> "결막";
+            case "lens" -> "수정체";
+            case "retina" -> "망막";
+            default -> null;
+        };
+
+        return area == null ? diseaseName : diseaseName + " | " + area;
+    }
+
+    private String normalizeDiseaseName(String diseaseName) {
+        if (diseaseName == null || diseaseName.isBlank()) {
+            throw new IllegalArgumentException("AI 질병명이 비어 있습니다.");
+        }
+
+        return switch (diseaseName.toLowerCase()) {
+            case "normal" -> "정상";
+            default -> diseaseName.trim();
+        };
+    }
+
+    private String normalizeSpecies(String species) {
+        if (species == null || species.isBlank()) {
+            throw new IllegalArgumentException("반려동물 종 정보가 비어 있습니다.");
+        }
+
+        return switch (species.toLowerCase()) {
+            case "dog", "강아지", "개" -> "DOG";
+            case "cat", "고양이" -> "CAT";
+            default -> species.toUpperCase();
+        };
+    }
+
+    private int formatConfidence(double confidence) {
+        return (int) Math.round(confidence * 100);
+    }
+
+    private String formatDescriptionTitle(String diseaseName) {
+        if ("정상".equals(diseaseName)) {
+            return "정상 안구입니다";
+        }
+
+        return diseaseName + "이 의심됩니다";
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
   profiles:
     active: local
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   sql:
     init:
       mode: always


### PR DESCRIPTION
## 📝 작업 내용

- 반려동물 안구 이미지 기반 AI 진단 API 구현
- 이미지 유효성 검사 서버, Cloudinary 이미지 업로드, AI 진단 서버 연동
- AI 진단 결과 DB 저장 및 클라이언트 화면 구조에 맞춘 응답 DTO 구성

---

## 🔥 변경 사항

- `POST /diagnoses` 진단 요청 API 구현
- multipart/form-data 기반 이미지 업로드 처리
- 이미지 유효성 검사 API 연동
- Cloudinary 업로드 후 이미지 URL 저장
- AI 서버 요청 DTO / 응답 DTO 구성
- AI 응답 disease 값을 `EyeDiseaseCode`와 매핑하여 `Diagnosis` 저장
- 진단 결과 응답 구조를 클라이언트 화면 기준으로 수정
  - `summary`
  - `resultCard`
- 증상 목록 미선택 시 빈 리스트로 처리하도록 nullable 대응
- 진단 결과 포맷팅 로직 추가
  - triage 상태값
  - 질병명 + 병변 부위
  - 신뢰도 퍼센트 변환
  - 안내 제목 생성

---

## 📸 스크린샷 (선택)
<img width="564" height="128" alt="스크린샷 2026-05-04 오후 5 29 09" src="https://github.com/user-attachments/assets/c067448d-04b4-46bd-8228-d0c28c27a33e" />

---

## ✅ 체크리스트

- [x] 기능 정상 동작 확인
- [x] 로컬 테스트 완료
- [ ] Swagger 테스트 완료

---

## 🔗 관련 이슈

Closes #13 

---

## 💬 기타 참고사항

- Swagger에서 multipart 파일 업로드 요청이 정상 전송되지 않는 이슈가 있어 curl 기반으로 로컬 테스트 진행