### PR TITLE
feat : 다이어리 생성에 필요한 get /diarys/checks API 추가, 반려동물 수정 삭제 추가.

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/pet/controller/PetController.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/controller/PetController.java
@@ -1,6 +1,7 @@
 package com.ppopi.ppopihouse.pet.controller;
 
 import com.ppopi.ppopihouse.diary.dto.DiaryDto;
+import com.ppopi.ppopihouse.pet.dto.request.PetUpdateRequest;
 import com.ppopi.ppopihouse.pet.service.PetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,32 @@ public class PetController {
             @AuthenticationPrincipal Long memberId) {
         return ResponseEntity.ok(petService.findPetSummaries(memberId));
     }
+
+    @Operation(summary = "반려동물 정보 수정", description = "기존 등록된 반려동물의 정보를 수정합니다.")
+    @PutMapping("/{petId}")
+    public ResponseEntity<String> updatePet(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long petId,
+            @RequestBody PetUpdateRequest request) {
+
+        petService.updatePet(memberId, petId, request);
+        return ResponseEntity.ok("success");
+    }
+
+    /**
+     * 반려동물 정보 삭제
+     * DELETE /pets/{petId}
+     */
+    @Operation(summary = "반려동물 정보 삭제", description = "등록된 반려동물 정보를 삭제합니다.")
+    @DeleteMapping("/{petId}")
+    public ResponseEntity<String> deletePet(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long petId) {
+
+        petService.deletePet(memberId, petId);
+        return ResponseEntity.ok("success");
+    }
+
     @Operation(
             summary = "품종 목록 조회",
             description = """

--- a/src/main/java/com/ppopi/ppopihouse/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/dto/request/PetUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.ppopi.ppopihouse.pet.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 반려동물 정보 수정 요청 DTO
+ */
+@Getter
+@Setter
+public class PetUpdateRequest {
+    private String name;
+    private String species;
+    private String breed;
+    private int age;
+    private String sex;
+    private int color;
+}

--- a/src/main/java/com/ppopi/ppopihouse/pet/dto/response/PetDetailResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/dto/response/PetDetailResponse.java
@@ -1,0 +1,22 @@
+package com.ppopi.ppopihouse.pet.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 반려동물 상세 정보 응답 DTO (수정 화면 진입 시 사용)
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class PetDetailResponse {
+    private Long petId;
+    private String name;
+    private String species;
+    private String breed;
+    private int birthYear;
+    private int age;
+    private String sex;
+    private int color;
+}

--- a/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
@@ -5,6 +5,7 @@ import com.ppopi.ppopihouse.member.domain.Member;
 import com.ppopi.ppopihouse.member.repository.MemberRepository;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.dto.request.PetCreateRequest;
+import com.ppopi.ppopihouse.pet.dto.request.PetUpdateRequest;
 import com.ppopi.ppopihouse.pet.dto.response.PetCreateResponse;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,63 @@ public class PetService {
                         .color(pet.getColor())
                         .build())
                 .collect(Collectors.toList());
+    }
+    /**
+     * 수정에서 사용할 유효성 검사
+     */
+    private void validatePetRequest(String name, String species, String breed, int age, String sex) {
+        if (name == null || name.isBlank()) throw new IllegalArgumentException("반려동물 이름은 필수입니다.");
+        if (species == null || species.isBlank()) throw new IllegalArgumentException("반려동물 종은 필수입니다.");
+        if (breed == null || breed.isBlank()) throw new IllegalArgumentException("품종은 필수입니다.");
+        if (age < 0 || age > 30) throw new IllegalArgumentException("올바르지 않은 나이입니다.");
+        if (sex == null || sex.isBlank()) throw new IllegalArgumentException("성별은 필수입니다.");
+    }
+
+    /**
+     * 반려동물 정보 수정
+     */
+    @Transactional
+    public void updatePet(Long memberId, Long petId, PetUpdateRequest request) {
+        // 1. 유효성 검사 (기존 create 로직과 동일한 기준 적용)
+        validatePetRequest(request.getName(), request.getSpecies(), request.getBreed(), request.getAge(), request.getSex());
+
+        // 2. 존재 여부 및 소유권 검증
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+
+        if (!pet.getMember().getMemberId().equals(memberId)) {
+            throw new SecurityException("해당 반려동물에 대한 수정 권한이 없습니다.");
+        }
+
+        // 3. 정보 갱신
+        pet.setName(request.getName());
+        pet.setSpecies(request.getSpecies());
+        pet.setBreed(request.getBreed());
+        pet.setBirthYear(calculateBirthYear(request.getAge()));
+        pet.setSex(request.getSex());
+        pet.setColor(request.getColor());
+
+    }
+    /**
+     * 반려동물 삭제
+     */
+    @Transactional
+    public void deletePet(Long memberId, Long petId) {
+        Pet pet = findValidatedPet(memberId, petId);
+        petRepository.delete(pet);
+    }
+
+    /**
+     * 반려동물 존재 여부 및 소유권 검증 공통 로직
+     */
+    private Pet findValidatedPet(Long memberId, Long petId) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+
+        if (!pet.getMember().getMemberId().equals(memberId)) {
+            throw new SecurityException("해당 반려동물에 대한 접근 권한이 없습니다.");
+        }
+        return pet;
     }
 
     public List<String> getBreeds(String species) {


### PR DESCRIPTION
 - DiaryDtop 파일에 CheckCodeResponse dto 생성
 - 해당 함수의 반환 객체에 checkId, checkName 포함해 반환하도록 개발.
 - get /diarys/checks 요청 시 [{"checkId": 0, "checkName": "string"}] 형식으로 반환되도록 설계 완료.
 - 반려동물 삭제 시 외래 키 문제로 삭제되지 않는 현상 아직 있음. DB 레벨에서 ON DELETE CASCADE 설정을 하는 것이 더 나을 것 같습니다. 의견 부탁드립니다.
 - 반려동물 수정에 대해서는 문제없이 잘 작동하는 것을 로컬로 확인.

## 📝 작업 내용

-

---

## 🔥 변경 사항

-

---

## 📸 스크린샷 (선택)

<!-- API 테스트 결과 / Swagger 캡처 등 -->

---

## ✅ 체크리스트

- [ ] 기능 정상 동작 확인
- [ ] 로컬 테스트 완료
- [ ] Swagger 테스트 완료
- [ ] 코드 리뷰 반영 완료

---

## 🔗 관련 이슈

Closes #

---

## 💬 기타 참고사항

-