### PR TITLE
[FIX] 진단시 다이어리 자동 생성

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
@@ -7,8 +7,9 @@ import java.util.Optional;
 
 public interface EyeDiseaseCodeRepository extends JpaRepository<EyeDiseaseCode, Long> {
 
-    Optional<EyeDiseaseCode> findByDiseaseNameAndInputSpecies(
+    Optional<EyeDiseaseCode> findByDiseaseNameAndInputSpeciesAndAffectedArea(
             String diseaseName,
-            String inputSpecies
+            String inputSpecies,
+            String affectedArea
     );
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -73,11 +73,18 @@ public class DiagnosisService {
 
         String diseaseName = normalizeDiseaseName(aiResponse.getDisease());
         String species = normalizeSpecies(pet.getSpecies());
+        String affectedArea = normalizeAffectedArea(aiResponse.getFamilyLabel());
 
         EyeDiseaseCode disease = eyeDiseaseCodeRepository
-                .findByDiseaseNameAndInputSpecies(diseaseName, species)
+                .findByDiseaseNameAndInputSpeciesAndAffectedArea(
+                        diseaseName,
+                        species,
+                        affectedArea
+                )
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "등록되지 않은 질병 코드입니다. disease=" + diseaseName + ", species=" + species
+                        "등록되지 않은 질병 코드입니다. disease=" + diseaseName
+                                + ", species=" + species
+                                + ", affectedArea=" + affectedArea
                 ));
 
         Diagnosis diagnosis = new Diagnosis();
@@ -222,5 +229,13 @@ public class DiagnosisService {
                 .filter(value -> !value.isBlank())
                 .map(Long::valueOf)
                 .toList();
+    }
+
+    private String normalizeAffectedArea(String affectedArea) {
+        if (affectedArea == null || affectedArea.isBlank()) {
+            throw new IllegalArgumentException("AI affectedArea 값이 비어 있습니다.");
+        }
+
+        return affectedArea.trim();
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,7 +82,7 @@ public class DiagnosisService {
 
         Diagnosis diagnosis = new Diagnosis();
         diagnosis.setPet(pet);
-        diagnosis.setDiagnosisDate(LocalDate.now());
+        diagnosis.setDiagnosisDate(LocalDate.now(ZoneId.of("Asia/Seoul")));
         diagnosis.setImageUrl(imageUrl);
         diagnosis.setDisease(disease);
 

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -10,6 +10,8 @@ import com.ppopi.ppopihouse.diagnosis.dto.response.DiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.dto.response.RecentDiagnosisResponse;
 import com.ppopi.ppopihouse.diagnosis.repository.DiagnosisRepository;
 import com.ppopi.ppopihouse.diagnosis.repository.EyeDiseaseCodeRepository;
+import com.ppopi.ppopihouse.diary.domain.DiaryEntry;
+import com.ppopi.ppopihouse.diary.repository.DiaryRepository;
 import com.ppopi.ppopihouse.global.infra.cloud.ImageStorageService;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
@@ -30,6 +32,7 @@ public class DiagnosisService {
 
     private final PetRepository petRepository;
     private final DiagnosisRepository diagnosisRepository;
+    private final DiaryRepository diaryRepository;
     private final EyeDiseaseCodeRepository eyeDiseaseCodeRepository;
     private final ImageValidationClient imageValidationClient;
     private final ImageStorageService imageStorageService;
@@ -107,7 +110,15 @@ public class DiagnosisService {
         diagnosis.setGuideAction(aiResponse.getGuidanceAction());
         diagnosis.setGuideWarn(aiResponse.getGuidanceWarning());
 
-        diagnosisRepository.save(diagnosis);
+        Diagnosis savedDiagnosis = diagnosisRepository.save(diagnosis);
+
+        DiaryEntry diaryEntry = new DiaryEntry();
+        diaryEntry.setPet(pet);
+        diaryEntry.setDiagnosis(savedDiagnosis);
+        diaryEntry.setEntryDate(LocalDate.now(ZoneId.of("Asia/Seoul")));
+        diaryEntry.setMemo(null);
+
+        diaryRepository.save(diaryEntry);
 
         return new DiagnosisResponse(
                 imageUrl,

--- a/src/main/java/com/ppopi/ppopihouse/pet/controller/PetController.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/controller/PetController.java
@@ -1,6 +1,7 @@
 package com.ppopi.ppopihouse.pet.controller;
 
 import com.ppopi.ppopihouse.diary.dto.DiaryDto;
+import com.ppopi.ppopihouse.pet.dto.request.PetUpdateRequest;
 import com.ppopi.ppopihouse.pet.service.PetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,32 @@ public class PetController {
             @AuthenticationPrincipal Long memberId) {
         return ResponseEntity.ok(petService.findPetSummaries(memberId));
     }
+
+    @Operation(summary = "반려동물 정보 수정", description = "기존 등록된 반려동물의 정보를 수정합니다.")
+    @PutMapping("/{petId}")
+    public ResponseEntity<String> updatePet(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long petId,
+            @RequestBody PetUpdateRequest request) {
+
+        petService.updatePet(memberId, petId, request);
+        return ResponseEntity.ok("success");
+    }
+
+    /**
+     * 반려동물 정보 삭제
+     * DELETE /pets/{petId}
+     */
+    @Operation(summary = "반려동물 정보 삭제", description = "등록된 반려동물 정보를 삭제합니다.")
+    @DeleteMapping("/{petId}")
+    public ResponseEntity<String> deletePet(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long petId) {
+
+        petService.deletePet(memberId, petId);
+        return ResponseEntity.ok("success");
+    }
+
     @Operation(
             summary = "품종 목록 조회",
             description = """

--- a/src/main/java/com/ppopi/ppopihouse/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/dto/request/PetUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.ppopi.ppopihouse.pet.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 반려동물 정보 수정 요청 DTO
+ */
+@Getter
+@Setter
+public class PetUpdateRequest {
+    private String name;
+    private String species;
+    private String breed;
+    private int age;
+    private String sex;
+    private int color;
+}

--- a/src/main/java/com/ppopi/ppopihouse/pet/dto/response/PetDetailResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/dto/response/PetDetailResponse.java
@@ -1,0 +1,22 @@
+package com.ppopi.ppopihouse.pet.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 반려동물 상세 정보 응답 DTO (수정 화면 진입 시 사용)
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class PetDetailResponse {
+    private Long petId;
+    private String name;
+    private String species;
+    private String breed;
+    private int birthYear;
+    private int age;
+    private String sex;
+    private int color;
+}

--- a/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
@@ -5,6 +5,7 @@ import com.ppopi.ppopihouse.member.domain.Member;
 import com.ppopi.ppopihouse.member.repository.MemberRepository;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.dto.request.PetCreateRequest;
+import com.ppopi.ppopihouse.pet.dto.request.PetUpdateRequest;
 import com.ppopi.ppopihouse.pet.dto.response.PetCreateResponse;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,63 @@ public class PetService {
                         .color(pet.getColor())
                         .build())
                 .collect(Collectors.toList());
+    }
+    /**
+     * 수정에서 사용할 유효성 검사
+     */
+    private void validatePetRequest(String name, String species, String breed, int age, String sex) {
+        if (name == null || name.isBlank()) throw new IllegalArgumentException("반려동물 이름은 필수입니다.");
+        if (species == null || species.isBlank()) throw new IllegalArgumentException("반려동물 종은 필수입니다.");
+        if (breed == null || breed.isBlank()) throw new IllegalArgumentException("품종은 필수입니다.");
+        if (age < 0 || age > 30) throw new IllegalArgumentException("올바르지 않은 나이입니다.");
+        if (sex == null || sex.isBlank()) throw new IllegalArgumentException("성별은 필수입니다.");
+    }
+
+    /**
+     * 반려동물 정보 수정
+     */
+    @Transactional
+    public void updatePet(Long memberId, Long petId, PetUpdateRequest request) {
+        // 1. 유효성 검사 (기존 create 로직과 동일한 기준 적용)
+        validatePetRequest(request.getName(), request.getSpecies(), request.getBreed(), request.getAge(), request.getSex());
+
+        // 2. 존재 여부 및 소유권 검증
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+
+        if (!pet.getMember().getMemberId().equals(memberId)) {
+            throw new SecurityException("해당 반려동물에 대한 수정 권한이 없습니다.");
+        }
+
+        // 3. 정보 갱신
+        pet.setName(request.getName());
+        pet.setSpecies(request.getSpecies());
+        pet.setBreed(request.getBreed());
+        pet.setBirthYear(calculateBirthYear(request.getAge()));
+        pet.setSex(request.getSex());
+        pet.setColor(request.getColor());
+
+    }
+    /**
+     * 반려동물 삭제
+     */
+    @Transactional
+    public void deletePet(Long memberId, Long petId) {
+        Pet pet = findValidatedPet(memberId, petId);
+        petRepository.delete(pet);
+    }
+
+    /**
+     * 반려동물 존재 여부 및 소유권 검증 공통 로직
+     */
+    private Pet findValidatedPet(Long memberId, Long petId) {
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+
+        if (!pet.getMember().getMemberId().equals(memberId)) {
+            throw new SecurityException("해당 반려동물에 대한 접근 권한이 없습니다.");
+        }
+        return pet;
     }
 
     public List<String> getBreeds(String species) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   application:
     name: ppopihouse
 
+  jackson:
+    time-zone: Asia/Seoul
+
   profiles:
     active: local
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     time-zone: Asia/Seoul
 
   profiles:
-    active: local
+    active: prod
 
   servlet:
     multipart:


### PR DESCRIPTION
## 📝 작업 내용

- AI 진단 요청 완료 시 다이어리가 자동 생성되도록 로직 추가

---

## 🔥 변경 사항

- `DiagnosisService.diagnose()` 내부에서 Diagnosis 저장 후 `DiaryEntry` 자동 생성 로직 추가
- 저장된 `Diagnosis` 엔티티를 `DiaryEntry`와 연결하도록 수정
- 자동 생성 다이어리는 현재 날짜 기준으로 저장되도록 처리

---


## ✅ 체크리스트

* [x] 기능 정상 동작 확인
* [x] 로컬 테스트 완료
* [x] Swagger 테스트 완료

---

## 🔗 관련 이슈

Closes #13 
