### PR TITLE
[FEAT] 로그아웃 및 회원탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/auth/controller/AuthController.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import com.ppopi.ppopihouse.auth.dto.response.TokenResponse;
 import com.ppopi.ppopihouse.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -39,7 +41,43 @@ public class AuthController {
                     """
     )
     @PostMapping("/reissue")
-    public TokenResponse reissue(@RequestBody RefreshTokenRequest request) {
+    public TokenResponse reissue(
+            @RequestBody RefreshTokenRequest request
+    ) {
         return authService.reissue(request.getRefreshToken());
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = """
+                현재 로그인한 회원의 refreshToken을 삭제하여 로그아웃 처리합니다.
+                
+                accessToken은 stateless 방식이므로 서버에서 직접 만료시키지 않고,
+                Redis에 저장된 refreshToken을 삭제하여 토큰 재발급을 차단합니다.
+                """
+    )
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        authService.logout(memberId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "회원탈퇴",
+            description = """
+                현재 로그인한 회원을 탈퇴 처리합니다.
+                
+                회원 데이터는 즉시 물리 삭제하지 않고 soft delete 방식으로 처리합니다.
+                탈퇴 시 Redis에 저장된 refreshToken을 삭제하여 재로그인 및 토큰 재발급을 차단합니다.
+                """
+    )
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        authService.withdraw(memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
@@ -11,10 +11,18 @@ import com.ppopi.ppopihouse.member.repository.MemberRepository;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.NoSuchElementException;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class AuthService {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     private final KakaoClient kakaoClient;
     private final MemberRepository memberRepository;
@@ -29,25 +37,17 @@ public class AuthService {
         String kakaoUserId = String.valueOf(kakaoUser.getId());
 
         Member member = memberRepository.findByKakaoUserId(kakaoUserId)
-                .orElseGet(() -> {
-                    Member newMember = new Member();
-                    newMember.setKakaoUserId(kakaoUserId);
-                    return memberRepository.save(newMember);
-                });
+                .orElseGet(() -> createMember(kakaoUserId));
+
+        validateActiveMember(member);
 
         boolean hasPet = petRepository.existsByMember(member);
         boolean isOnboarding = !hasPet;
 
-        // ✅ 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(member.getMemberId());
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getMemberId());
 
-        // ✅ Redis 저장
-        refreshTokenRepository.save(
-                member.getMemberId(),
-                refreshToken,
-                jwtProperties.getRefreshExpiration()
-        );
+        saveRefreshToken(member.getMemberId(), refreshToken);
 
         return new LoginResponse(
                 member.getMemberId(),
@@ -58,10 +58,12 @@ public class AuthService {
     }
 
     public TokenResponse reissue(String refreshToken) {
-
         jwtTokenProvider.validateOrThrow(refreshToken);
 
         Long memberId = jwtTokenProvider.getMemberId(refreshToken);
+
+        Member member = findMember(memberId);
+        validateActiveMemberForReissue(member);
 
         String savedToken = refreshTokenRepository.find(memberId);
 
@@ -72,11 +74,7 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(memberId);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
 
-        refreshTokenRepository.save(
-                memberId,
-                newRefreshToken,
-                jwtProperties.getRefreshExpiration()
-        );
+        saveRefreshToken(memberId, newRefreshToken);
 
         return new TokenResponse(newAccessToken, newRefreshToken);
     }
@@ -85,4 +83,48 @@ public class AuthService {
         refreshTokenRepository.delete(memberId);
     }
 
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = findMember(memberId);
+
+        if (member.isDeleted()) {
+            refreshTokenRepository.delete(memberId);
+            return;
+        }
+
+        refreshTokenRepository.delete(memberId);
+        member.withdraw(LocalDateTime.now(SEOUL_ZONE));
+    }
+
+    private Member createMember(String kakaoUserId) {
+        Member member = new Member();
+        member.setKakaoUserId(kakaoUserId);
+        return memberRepository.save(member);
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+    }
+
+    private void validateActiveMember(Member member) {
+        if (member.isDeleted()) {
+            throw new UnauthorizedException("탈퇴한 회원입니다.");
+        }
+    }
+
+    private void validateActiveMemberForReissue(Member member) {
+        if (member.isDeleted()) {
+            refreshTokenRepository.delete(member.getMemberId());
+            throw new UnauthorizedException("탈퇴한 회원입니다.");
+        }
+    }
+
+    private void saveRefreshToken(Long memberId, String refreshToken) {
+        refreshTokenRepository.save(
+                memberId,
+                refreshToken,
+                jwtProperties.getRefreshExpiration()
+        );
+    }
 }

--- a/src/main/java/com/ppopi/ppopihouse/member/domain/Member.java
+++ b/src/main/java/com/ppopi/ppopihouse/member/domain/Member.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "member")
 @Getter
@@ -19,4 +21,14 @@ public class Member {
 
     @Column(name = "kakao_user_id", nullable = false, unique = true)
     private String kakaoUserId;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
+
+    public void withdraw(LocalDateTime deletedAt) {
+        this.deleted = true;
+        this.deletedAt = deletedAt;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

* 로그아웃 및 회원탈퇴 API 추가
* soft delete 기반 회원탈퇴 로직 구현
* JWT 인증/인가 흐름 개선
* 인증 오류 응답 및 timestamp 직렬화 문제 수정

---

## 🔥 변경 사항

* `/auth/logout` API 추가

  * Redis refreshToken 삭제 처리
* `/auth/withdraw` API 추가

  * 회원 soft delete 처리
  * deleted / deletedAt 필드 추가
* `AuthService`

  * 탈퇴 회원 로그인 차단
  * 탈퇴 회원 토큰 재발급 차단
  * refresh token 검증 로직 개선
* `JwtAuthenticationFilter`

  * 인증 실패 시 JSON 응답 반환
  * timestamp 포함 ErrorResponse 반환
* `ErrorResponse`

  * timestamp 필드 추가
  * OffsetDateTime 직렬화 오류 수정
* `SecurityConfig`

  * Spring Security 기본 logout 비활성화
* Swagger API 설명 추가 및 정리

---

## ✅ 체크리스트

* [x] 기능 정상 동작 확인
* [x] 로컬 테스트 완료
* [x] Swagger 테스트 완료

---

## 🔗 관련 이슈

Closes #64 

---

## 💬 기타 참고사항

* 회원탈퇴는 cascade delete 대신 soft delete 방식으로 구현
* AccessToken은 stateless 구조이므로 서버에서 직접 만료시키지 않음
* 로그아웃 및 회원탈퇴 시 Redis refreshToken 삭제를 통해 재발급 차단
