### PR TITLE
[FIX] 인증 및 회원탈퇴 로직 개선

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/auth/controller/AuthController.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/controller/AuthController.java
@@ -4,10 +4,12 @@ import com.ppopi.ppopihouse.auth.dto.request.KakaoLoginRequest;
 import com.ppopi.ppopihouse.auth.dto.request.RefreshTokenRequest;
 import com.ppopi.ppopihouse.auth.dto.response.LoginResponse;
 import com.ppopi.ppopihouse.auth.dto.response.TokenResponse;
+import com.ppopi.ppopihouse.auth.security.CustomUserDetails;
 import com.ppopi.ppopihouse.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -58,9 +60,10 @@ public class AuthController {
     )
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(
-            @AuthenticationPrincipal Long memberId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        authService.logout(memberId);
+        authService.logout(userDetails.getMemberId());
+
         return ResponseEntity.ok().build();
     }
 
@@ -75,9 +78,9 @@ public class AuthController {
     )
     @DeleteMapping("/withdraw")
     public ResponseEntity<Void> withdraw(
-            @AuthenticationPrincipal Long memberId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        authService.withdraw(memberId);
+        authService.withdraw(userDetails.getMemberId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/security/CustomUserDetails.java
@@ -1,0 +1,31 @@
+package com.ppopi.ppopihouse.auth.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Long memberId;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(memberId);
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
-package com.ppopi.ppopihouse.auth.service;
+package com.ppopi.ppopihouse.auth.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppopi.ppopihouse.auth.service.JwtTokenProvider;
 import com.ppopi.ppopihouse.global.exception.ErrorResponse;
 import com.ppopi.ppopihouse.global.exception.UnauthorizedException;
 import jakarta.servlet.FilterChain;
@@ -40,8 +41,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 Long memberId = jwtTokenProvider.getMemberId(token);
 
+                CustomUserDetails userDetails = new CustomUserDetails(memberId);
+
                 UsernamePasswordAuthenticationToken auth =
-                        new UsernamePasswordAuthenticationToken(memberId, null, List.of());
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
 
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
@@ -66,10 +73,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
 
-        return path.startsWith("/auth/")
+        return path.equals("/auth/kakao")
+                || path.equals("/auth/reissue")
                 || path.startsWith("/swagger-ui/")
                 || path.startsWith("/v3/api-docs/")
                 || path.equals("/swagger-ui.html");
     }
-
 }

--- a/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
@@ -8,13 +8,16 @@ import com.ppopi.ppopihouse.auth.repository.RefreshTokenRepository;
 import com.ppopi.ppopihouse.global.exception.UnauthorizedException;
 import com.ppopi.ppopihouse.member.domain.Member;
 import com.ppopi.ppopihouse.member.repository.MemberRepository;
+import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -37,11 +40,15 @@ public class AuthService {
         String kakaoUserId = String.valueOf(kakaoUser.getId());
 
         Member member = memberRepository.findByKakaoUserId(kakaoUserId)
+                .map(existingMember -> {
+                    if (existingMember.isDeleted()) {
+                        existingMember.rejoin();
+                    }
+                    return existingMember;
+                })
                 .orElseGet(() -> createMember(kakaoUserId));
 
-        validateActiveMember(member);
-
-        boolean hasPet = petRepository.existsByMember(member);
+        boolean hasPet = petRepository.existsByMemberAndDeletedFalse(member);
         boolean isOnboarding = !hasPet;
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getMemberId());
@@ -80,20 +87,32 @@ public class AuthService {
     }
 
     public void logout(Long memberId) {
+        System.out.println("logout memberId = " + memberId);
+
         refreshTokenRepository.delete(memberId);
+
+        String savedToken = refreshTokenRepository.find(memberId);
+        System.out.println("logout 후 refreshToken = " + savedToken);
     }
 
     @Transactional
     public void withdraw(Long memberId) {
         Member member = findMember(memberId);
 
+        refreshTokenRepository.delete(memberId);
+
         if (member.isDeleted()) {
-            refreshTokenRepository.delete(memberId);
             return;
         }
 
-        refreshTokenRepository.delete(memberId);
-        member.withdraw(LocalDateTime.now(SEOUL_ZONE));
+        List<Pet> pets = petRepository.findAllByMemberAndDeletedFalse(member);
+        LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
+
+        for (Pet pet : pets) {
+            pet.delete(now);
+        }
+
+        member.withdraw(now);
     }
 
     private Member createMember(String kakaoUserId) {

--- a/src/main/java/com/ppopi/ppopihouse/auth/service/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/service/JwtAuthenticationFilter.java
@@ -61,4 +61,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             );
         }
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+
+        return path.startsWith("/auth/")
+                || path.startsWith("/swagger-ui/")
+                || path.startsWith("/v3/api-docs/")
+                || path.equals("/swagger-ui.html");
+    }
+
 }

--- a/src/main/java/com/ppopi/ppopihouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.ppopi.ppopihouse.global.config;
 
-import com.ppopi.ppopihouse.auth.service.JwtAuthenticationFilter;
+import com.ppopi.ppopihouse.auth.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,11 +27,13 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/auth/**",
+                                "/auth/kakao",
+                                "/auth/reissue",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**"
                         ).permitAll()
+                        .requestMatchers("/auth/logout", "/auth/withdraw").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/ppopi/ppopihouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
+                .logout(logout -> logout.disable())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )

--- a/src/main/java/com/ppopi/ppopihouse/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/exception/ErrorResponse.java
@@ -1,24 +1,24 @@
 package com.ppopi.ppopihouse.global.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 @Getter
-@AllArgsConstructor
 public class ErrorResponse {
 
-    private final OffsetDateTime timestamp;
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
-    private String code;
-    private String message;
+    private final String timestamp;
+    private final String code;
+    private final String message;
 
     public ErrorResponse(String code, String message) {
+        this.timestamp = OffsetDateTime.now(SEOUL_ZONE)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         this.code = code;
         this.message = message;
-        this.timestamp = OffsetDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/member/domain/Member.java
+++ b/src/main/java/com/ppopi/ppopihouse/member/domain/Member.java
@@ -31,4 +31,9 @@ public class Member {
         this.deleted = true;
         this.deletedAt = deletedAt;
     }
+
+    public void rejoin() {
+        this.deleted = false;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/ppopi/ppopihouse/pet/domain/Pet.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/domain/Pet.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "pet")
 @Getter
@@ -39,4 +41,19 @@ public class Pet {
 
     @Column(nullable = false)
     private int color;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
+
+    public void delete(LocalDateTime deletedAt) {
+        this.deleted = true;
+        this.deletedAt = deletedAt;
+    }
+
+    public void restore() {
+        this.deleted = false;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
@@ -11,4 +11,7 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     boolean existsByMember(Member member);
     long countByMember_MemberId(Long memberId);
     List<Pet> findAllByMember_MemberId(Long memberId);
+    void deleteByMember(Member member);
+    boolean existsByMemberAndDeletedFalse(Member member);
+    List<Pet> findAllByMemberAndDeletedFalse(Member member);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,10 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD:}
+      password: ${REDIS_PASSWORD}
+      username: ${REDIS_USERNAME}
+      ssl:
+        enabled: ${REDIS_SSL}
 
   datasource:
     url: ${DB_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,5 +1,6 @@
 server:
   port: ${PORT:8080}
+  forward-headers-strategy: framework
 
 spring:
   data:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     time-zone: Asia/Seoul
 
   profiles:
-    active: prod
+    active: local
 
   servlet:
     multipart:


### PR DESCRIPTION
## 📝 작업 내용

* JWT 인증 필터 구조 개선
* 로그아웃 시 refresh token 정상 삭제 처리
* refresh token 재발급 검증 로직 수정
* 탈퇴 회원 재가입 처리 추가
* Pet soft delete 적용
* 탈퇴 후 온보딩 로직 수정
* Railway HTTPS / Redis SSL 설정 반영

---

## 🔥 변경 사항

### 인증 / JWT

* `/auth/logout`, `/auth/withdraw`에 JWT 인증 적용
* `CustomUserDetails` 도입
* 로그아웃 후 refresh token 재발급 차단
* refresh token rotation 로직 수정

### 회원탈퇴 / 재가입

* `Member` soft delete 처리 유지
* 탈퇴 회원 재로그인 시 계정 복구 처리 추가
* `Pet` soft delete 적용
* 탈퇴 후 재가입 시 온보딩이 정상적으로 `true` 반환되도록 수정

### 배포 / 인프라

* Railway HTTPS 프록시 설정 추가
* Redis SSL 연결 설정 추가
* Redis 환경변수 구조 수정

---

## ✅ 체크리스트

* [x] 로그인 테스트 완료
* [x] 토큰 재발급 테스트 완료
* [x] 로그아웃 후 재발급 차단 확인
* [x] 회원탈퇴 / 재가입 테스트 완료
* [x] Railway 배포 테스트 완료

---

## 🔗 관련 이슈

Closes #64

---

## 💬 기타 참고사항

* Redis 기반 refresh token 관리 구조로 변경
* JWT stateless 구조 유지
