### PR TITLE
[FIX] pet soft delete 및 AI nullable 응답 처리 개선

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
@@ -11,7 +11,6 @@ import com.ppopi.ppopihouse.member.repository.MemberRepository;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -105,7 +104,7 @@ public class AuthService {
             return;
         }
 
-        List<Pet> pets = petRepository.findAllByMemberAndDeletedFalse(member);
+        List<Pet> pets = petRepository.findAllByMemberAndDeletedFalseOrderByPetIdAsc(member);
         LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
 
         for (Pet pet : pets) {

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
@@ -12,4 +12,9 @@ public interface EyeDiseaseCodeRepository extends JpaRepository<EyeDiseaseCode, 
             String inputSpecies,
             String affectedArea
     );
+
+    Optional<EyeDiseaseCode> findByDiseaseNameAndInputSpecies(
+            String diseaseName,
+            String inputSpecies
+    );
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -153,7 +153,20 @@ public class DiagnosisService {
     private EyeDiseaseCode findDiseaseCode(Pet pet, AiDiagnosisResponse aiResponse) {
         String diseaseName = normalizeDiseaseName(aiResponse.getDisease());
         String species = normalizeSpecies(pet.getSpecies());
-        String affectedArea = normalizeAffectedArea(aiResponse.getFamilyLabel());
+
+        if ("정상".equals(diseaseName)) {
+            return eyeDiseaseCodeRepository
+                    .findByDiseaseNameAndInputSpecies(
+                            diseaseName,
+                            species
+                    )
+                    .orElseThrow(() -> new NoSuchElementException(
+                            "등록되지 않은 정상 질병 코드입니다."
+                    ));
+        }
+
+        String affectedArea =
+                normalizeAffectedArea(aiResponse.getFamilyLabel(), diseaseName);
 
         return eyeDiseaseCodeRepository
                 .findByDiseaseNameAndInputSpeciesAndAffectedArea(
@@ -162,9 +175,7 @@ public class DiagnosisService {
                         affectedArea
                 )
                 .orElseThrow(() -> new NoSuchElementException(
-                        "등록되지 않은 질병 코드입니다. disease=" + diseaseName
-                                + ", species=" + species
-                                + ", affectedArea=" + affectedArea
+                        "등록되지 않은 질병 코드입니다."
                 ));
     }
 
@@ -273,8 +284,14 @@ public class DiagnosisService {
         };
     }
 
-    private String normalizeAffectedArea(String affectedArea) {
+    private String normalizeAffectedArea(String affectedArea, String diseaseName) {
+        boolean isNormal = "정상".equals(diseaseName);
+
         if (affectedArea == null || affectedArea.isBlank()) {
+            if (isNormal) {
+                return null;
+            }
+
             throw new IllegalArgumentException("AI affectedArea 값이 비어 있습니다.");
         }
 

--- a/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
@@ -5,13 +5,13 @@ import com.ppopi.ppopihouse.pet.domain.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
 
-    boolean existsByMember(Member member);
     long countByMember_MemberId(Long memberId);
     List<Pet> findAllByMember_MemberId(Long memberId);
-    void deleteByMember(Member member);
     boolean existsByMemberAndDeletedFalse(Member member);
-    List<Pet> findAllByMemberAndDeletedFalse(Member member);
+    List<Pet> findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(Long memberId);
+    Optional<Pet> findByPetIdAndMember_MemberIdAndDeletedFalse(Long petId, Long memberId);
 }

--- a/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
@@ -13,6 +13,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -32,7 +34,8 @@ public class PetService {
     public List<DiaryDto.PetSummary> findPetSummaries(Long memberId) {
         int currentYear = LocalDate.now().getYear(); // 2026년 기준
 
-        return petRepository.findAllByMember_MemberId(memberId).stream()
+        return petRepository
+                .findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(memberId).stream()
                 .map(pet -> DiaryDto.PetSummary.builder()
                         .petId(pet.getPetId())
                         .name(pet.getName())
@@ -71,9 +74,8 @@ public class PetService {
     @Transactional
     public void deletePet(Long memberId, Long petId) {
         Pet pet = findValidatedPet(memberId, petId);
-        petRepository.delete(pet);
+        pet.delete(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
     }
-
 
     public List<String> getBreeds(String species) {
         return PetBreedProvider.getBreeds(species);
@@ -109,14 +111,8 @@ public class PetService {
      * 반려동물 존재 여부 및 소유권 검증 공통 로직
      */
     private Pet findValidatedPet(Long memberId, Long petId) {
-        Pet pet = petRepository.findById(petId)
+        return petRepository.findByPetIdAndMember_MemberIdAndDeletedFalse(petId, memberId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 반려동물입니다."));
-
-        if (!pet.getMember().getMemberId().equals(memberId)) {
-            throw new AccessDeniedException("해당 반려동물에 대한 접근 권한이 없습니다.");
-        }
-
-        return pet;
     }
 
     /**


### PR DESCRIPTION
## 📝 작업 내용

* 반려동물 soft delete 구조 보완
* 반려동물 목록 등록순 정렬 적용
* 반려동물 삭제 API 500 오류 수정
* AI 정상 진단 nullable 필드 처리 개선
* 진단 질병 코드 조회 로직 개선

---

## 🔥 변경 사항

### 반려동물 조회 및 삭제 구조 개선

* 반려동물 목록 조회 시 `petId` 오름차순 기준 정렬 적용
* 삭제된 반려동물 제외 후 조회하도록 수정
* soft delete 적용 이후 반려동물 등록 제한 로직 수정
* 삭제된 반려동물은 등록 가능 수 계산에서 제외되도록 수정

### 반려동물 삭제 API 수정

* `petRepository.delete()` 기반 물리 삭제 제거
* `deleted`, `deleted_at` 기반 soft delete 구조 적용
* 연관 데이터(FK) 충돌로 발생하던 500 오류 해결

### AI 정상 진단 nullable 처리 개선

* 정상(normal) 진단 결과에서는 nullable 필드 허용
* `affectedArea`, `familyLabel` blank/null 값 처리 개선
* 질병 진단 결과에서만 affectedArea 검증 수행하도록 수정

### 질병 코드 조회 로직 개선

* 정상 질환(`정상`)은 affectedArea 없이 질병 코드 조회 가능하도록 분기 처리
* `findByDiseaseNameAndInputSpecies()` 메서드 추가
* 질병 유형별 조회 조건 분리 적용

---

## ✅ 체크리스트

* [x] 반려동물 목록 등록순 반환 확인
* [x] 삭제된 반려동물 조회 제외 확인
* [x] 반려동물 삭제 API 정상 동작 확인
* [x] soft delete 이후 등록 제한 정상 동작 확인
* [x] 정상 안구 진단 결과 nullable 처리 확인
* [x] 질병 진단 결과 affectedArea 검증 확인
* [x] 진단 API 테스트 완료

---

## 🔗 관련 이슈

Closes #69

---

## 💬 기타 참고사항

* soft delete 구조 기준으로 pet 조회/삭제/등록 제한 로직 전체 정리
* 정상(normal) AI 응답과 질병 응답의 검증 로직 분리 적용
