### PR TITLE
fix : get /diarys/checks API 오류 수정

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
@@ -9,6 +9,8 @@ import com.ppopi.ppopihouse.diary.dto.DiaryResponseDto;
 import com.ppopi.ppopihouse.diary.repository.*;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
+import com.ppopi.ppopihouse.diagnosis.domain.EyeSymptom; // Enum 임포트
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -108,11 +110,14 @@ public class DiaryService {
     }
 
     /**
-     * 다이어리 작성을 위한 증상 체크리스트 전체 조회
+     * 다이어리 작성을 위한 증상 체크리스트 전체 조회 (Enum 기반)
      */
     public List<DiaryDto.CheckCodeResponse> findAllCheckCodes() {
-        return checkCodeRepository.findAll().stream()
-                .map(code -> new DiaryDto.CheckCodeResponse(code.getCheckId(), code.getCheckName()))
+        return Arrays.stream(EyeSymptom.values())
+                .map(symptom -> DiaryDto.CheckCodeResponse.builder()
+                        .checkId(symptom.getId())
+                        .checkName(symptom.getDescription())
+                        .build())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
 - 해당 값을 DB에서 꺼내오던 로직에서 .diagnosis.domain.EyeSymptom.java에 하드코딩된 데이터를 연동시키도록 Service단 코드 수정

## 📝 작업 내용

-

---

## 🔥 변경 사항

-

---

## 📸 스크린샷 (선택)

<!-- API 테스트 결과 / Swagger 캡처 등 -->

---

## ✅ 체크리스트

- [ ] 기능 정상 동작 확인
- [ ] 로컬 테스트 완료
- [ ] Swagger 테스트 완료
- [ ] 코드 리뷰 반영 완료

---

## 🔗 관련 이슈

Closes #

---

## 💬 기타 참고사항

-