### PR TITLE
[FIX] 다이어리 최신 진단 반영 및 회원탈퇴 API 경로 이슈 수정

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
+++ b/src/main/java/com/ppopi/ppopihouse/auth/service/AuthService.java
@@ -11,7 +11,6 @@ import com.ppopi.ppopihouse.member.repository.MemberRepository;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -105,7 +104,7 @@ public class AuthService {
             return;
         }
 
-        List<Pet> pets = petRepository.findAllByMemberAndDeletedFalse(member);
+        List<Pet> pets = petRepository.findAllByMemberAndDeletedFalseOrderByPetIdAsc(member);
         LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
 
         for (Pet pet : pets) {

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/repository/EyeDiseaseCodeRepository.java
@@ -12,4 +12,9 @@ public interface EyeDiseaseCodeRepository extends JpaRepository<EyeDiseaseCode, 
             String inputSpecies,
             String affectedArea
     );
+
+    Optional<EyeDiseaseCode> findByDiseaseNameAndInputSpecies(
+            String diseaseName,
+            String inputSpecies
+    );
 }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -202,11 +202,19 @@ public class DiagnosisService {
     }
 
     private void createDiaryFromDiagnosis(Pet pet, Diagnosis diagnosis) {
-        DiaryEntry diaryEntry = new DiaryEntry();
-        diaryEntry.setPet(pet);
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+
+        DiaryEntry diaryEntry = diaryRepository
+                .findByPet_PetIdAndEntryDate(pet.getPetId(), today)
+                .orElseGet(() -> {
+                    DiaryEntry newDiaryEntry = new DiaryEntry();
+                    newDiaryEntry.setPet(pet);
+                    newDiaryEntry.setEntryDate(today);
+                    newDiaryEntry.setMemo(null);
+                    return newDiaryEntry;
+                });
+
         diaryEntry.setDiagnosis(diagnosis);
-        diaryEntry.setEntryDate(LocalDate.now(SEOUL_ZONE));
-        diaryEntry.setMemo(null);
 
         diaryRepository.save(diaryEntry);
     }

--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -153,7 +153,20 @@ public class DiagnosisService {
     private EyeDiseaseCode findDiseaseCode(Pet pet, AiDiagnosisResponse aiResponse) {
         String diseaseName = normalizeDiseaseName(aiResponse.getDisease());
         String species = normalizeSpecies(pet.getSpecies());
-        String affectedArea = normalizeAffectedArea(aiResponse.getFamilyLabel());
+
+        if ("정상".equals(diseaseName)) {
+            return eyeDiseaseCodeRepository
+                    .findByDiseaseNameAndInputSpecies(
+                            diseaseName,
+                            species
+                    )
+                    .orElseThrow(() -> new NoSuchElementException(
+                            "등록되지 않은 정상 질병 코드입니다."
+                    ));
+        }
+
+        String affectedArea =
+                normalizeAffectedArea(aiResponse.getFamilyLabel(), diseaseName);
 
         return eyeDiseaseCodeRepository
                 .findByDiseaseNameAndInputSpeciesAndAffectedArea(
@@ -162,9 +175,7 @@ public class DiagnosisService {
                         affectedArea
                 )
                 .orElseThrow(() -> new NoSuchElementException(
-                        "등록되지 않은 질병 코드입니다. disease=" + diseaseName
-                                + ", species=" + species
-                                + ", affectedArea=" + affectedArea
+                        "등록되지 않은 질병 코드입니다."
                 ));
     }
 
@@ -273,8 +284,14 @@ public class DiagnosisService {
         };
     }
 
-    private String normalizeAffectedArea(String affectedArea) {
+    private String normalizeAffectedArea(String affectedArea, String diseaseName) {
+        boolean isNormal = "정상".equals(diseaseName);
+
         if (affectedArea == null || affectedArea.isBlank()) {
+            if (isNormal) {
+                return null;
+            }
+
             throw new IllegalArgumentException("AI affectedArea 값이 비어 있습니다.");
         }
 

--- a/src/main/java/com/ppopi/ppopihouse/diary/domain/DiaryEntry.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/domain/DiaryEntry.java
@@ -33,4 +33,8 @@ public class DiaryEntry {
     private LocalDate entryDate;
 
     private String memo;
+
+    public void updateDiagnosis(Diagnosis diagnosis) {
+        this.diagnosis = diagnosis;
+    }
 }

--- a/src/main/java/com/ppopi/ppopihouse/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/repository/DiaryRepository.java
@@ -5,6 +5,7 @@ import com.ppopi.ppopihouse.pet.domain.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntry, Long> {
     // 특정 펫 리스트의 기간 내 다이어리 조회
@@ -12,4 +13,6 @@ public interface DiaryRepository extends JpaRepository<DiaryEntry, Long> {
 
     // 일별 조회를 위한 메서드 추가
     List<DiaryEntry> findAllByPetInAndEntryDate(List<Pet> pets, LocalDate entryDate);
+
+    Optional<DiaryEntry> findByPet_PetIdAndEntryDate(Long petId, LocalDate entryDate);
 }

--- a/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
@@ -9,8 +9,6 @@ import com.ppopi.ppopihouse.diary.dto.DiaryResponseDto;
 import com.ppopi.ppopihouse.diary.repository.*;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
-import com.ppopi.ppopihouse.diagnosis.domain.EyeSymptom; // Enum 임포트
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -110,14 +108,11 @@ public class DiaryService {
     }
 
     /**
-     * 다이어리 작성을 위한 증상 체크리스트 전체 조회 (Enum 기반)
+     * 다이어리 작성을 위한 증상 체크리스트 전체 조회
      */
     public List<DiaryDto.CheckCodeResponse> findAllCheckCodes() {
-        return Arrays.stream(EyeSymptom.values())
-                .map(symptom -> DiaryDto.CheckCodeResponse.builder()
-                        .checkId(symptom.getId())
-                        .checkName(symptom.getDescription())
-                        .build())
+        return checkCodeRepository.findAll().stream()
+                .map(code -> new DiaryDto.CheckCodeResponse(code.getCheckId(), code.getCheckName()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
@@ -9,6 +9,8 @@ import com.ppopi.ppopihouse.diary.dto.DiaryResponseDto;
 import com.ppopi.ppopihouse.diary.repository.*;
 import com.ppopi.ppopihouse.pet.domain.Pet;
 import com.ppopi.ppopihouse.pet.repository.PetRepository;
+import com.ppopi.ppopihouse.diagnosis.domain.EyeSymptom; // Enum 임포트
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -108,11 +110,14 @@ public class DiaryService {
     }
 
     /**
-     * 다이어리 작성을 위한 증상 체크리스트 전체 조회
+     * 다이어리 작성을 위한 증상 체크리스트 전체 조회 (Enum 기반)
      */
     public List<DiaryDto.CheckCodeResponse> findAllCheckCodes() {
-        return checkCodeRepository.findAll().stream()
-                .map(code -> new DiaryDto.CheckCodeResponse(code.getCheckId(), code.getCheckName()))
+        return Arrays.stream(EyeSymptom.values())
+                .map(symptom -> DiaryDto.CheckCodeResponse.builder()
+                        .checkId(symptom.getId())
+                        .checkName(symptom.getDescription())
+                        .build())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
@@ -8,10 +8,18 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
+    long countByMember_MemberIdAndDeletedFalse(Long memberId);
 
-    long countByMember_MemberId(Long memberId);
     List<Pet> findAllByMember_MemberId(Long memberId);
+
     boolean existsByMemberAndDeletedFalse(Member member);
+
+    List<Pet> findAllByMemberAndDeletedFalseOrderByPetIdAsc(Member member);
+
     List<Pet> findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(Long memberId);
-    Optional<Pet> findByPetIdAndMember_MemberIdAndDeletedFalse(Long petId, Long memberId);
+
+    Optional<Pet> findByPetIdAndMember_MemberIdAndDeletedFalse(
+            Long petId,
+            Long memberId
+    );
 }

--- a/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
@@ -5,13 +5,13 @@ import com.ppopi.ppopihouse.pet.domain.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
 
-    boolean existsByMember(Member member);
     long countByMember_MemberId(Long memberId);
     List<Pet> findAllByMember_MemberId(Long memberId);
-    void deleteByMember(Member member);
     boolean existsByMemberAndDeletedFalse(Member member);
-    List<Pet> findAllByMemberAndDeletedFalse(Member member);
+    List<Pet> findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(Long memberId);
+    Optional<Pet> findByPetIdAndMember_MemberIdAndDeletedFalse(Long petId, Long memberId);
 }

--- a/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
@@ -13,6 +13,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -32,7 +34,8 @@ public class PetService {
     public List<DiaryDto.PetSummary> findPetSummaries(Long memberId) {
         int currentYear = LocalDate.now().getYear(); // 2026년 기준
 
-        return petRepository.findAllByMember_MemberId(memberId).stream()
+        return petRepository
+                .findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(memberId).stream()
                 .map(pet -> DiaryDto.PetSummary.builder()
                         .petId(pet.getPetId())
                         .name(pet.getName())
@@ -71,9 +74,8 @@ public class PetService {
     @Transactional
     public void deletePet(Long memberId, Long petId) {
         Pet pet = findValidatedPet(memberId, petId);
-        petRepository.delete(pet);
+        pet.delete(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
     }
-
 
     public List<String> getBreeds(String species) {
         return PetBreedProvider.getBreeds(species);
@@ -109,14 +111,8 @@ public class PetService {
      * 반려동물 존재 여부 및 소유권 검증 공통 로직
      */
     private Pet findValidatedPet(Long memberId, Long petId) {
-        Pet pet = petRepository.findById(petId)
+        return petRepository.findByPetIdAndMember_MemberIdAndDeletedFalse(petId, memberId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 반려동물입니다."));
-
-        if (!pet.getMember().getMemberId().equals(memberId)) {
-            throw new AccessDeniedException("해당 반려동물에 대한 접근 권한이 없습니다.");
-        }
-
-        return pet;
     }
 
     /**

--- a/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/service/PetService.java
@@ -88,7 +88,7 @@ public class PetService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
 
-        long petCount = petRepository.countByMember_MemberId(memberId);
+        long petCount = petRepository.countByMember_MemberIdAndDeletedFalse(memberId);
         if (petCount >= 3) {
             throw new IllegalArgumentException("반려동물은 최대 3마리까지 등록할 수 있습니다.");
         }


### PR DESCRIPTION
## 📝 작업 내용

* 동일 날짜에 여러 번 진단을 수행할 경우 기존 다이어리를 업데이트하도록 로직 수정
* 삭제된 반려동물이 다이어리 조회 결과에 포함되지 않도록 수정

---

## 🔥 변경 사항

### 1. 동일 날짜 진단 시 최신 진단 결과로 다이어리 업데이트

기존에는 같은 날짜에 진단을 여러 번 수행할 경우 `DiaryEntry`가 계속 새로 생성되는 구조였음.

이를 수정하여:

* `petId + entryDate` 기준으로 기존 다이어리를 조회
* 기존 다이어리가 존재할 경우 최신 `Diagnosis`로 업데이트
* 존재하지 않을 경우에만 새로운 `DiaryEntry` 생성

하도록 변경함.

---

### 2. 삭제된 반려동물의 다이어리 조회 제외

기존 다이어리 조회 로직에서:

```java
findAllByMember_MemberId()
```

를 사용하고 있어 soft delete 처리된 반려동물까지 조회되고 있었음.

이를:

```java
findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc()
```

기준으로 수정하여 삭제된 반려동물의 다이어리가 사용자 화면에 노출되지 않도록 변경함.


---

## ✅ 체크리스트

* [x] 동일 날짜 진단 시 다이어리 중복 생성 방지 확인
* [x] 최신 진단 결과로 다이어리 업데이트 확인
* [x] 삭제된 반려동물 다이어리 조회 제외 확인
* [x] 회원탈퇴 API 정상 동작 확인
* [x] 로컬 테스트 완료
* [ ] Swagger 테스트 완료

---

## 🔗 관련 이슈

Closes #75

---

## 💬 기타 참고사항

* 다이어리 생성 기준을 `petId + entryDate` 기준으로 통일
* soft delete 구조 적용 이후 조회 로직 전반에 `deleted=false` 조건 반영 필요
