### PR TITLE
[FIX] 다이어리 조회 및 공통 예외 처리 개선

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diagnosis/service/DiagnosisService.java
@@ -202,11 +202,19 @@ public class DiagnosisService {
     }
 
     private void createDiaryFromDiagnosis(Pet pet, Diagnosis diagnosis) {
-        DiaryEntry diaryEntry = new DiaryEntry();
-        diaryEntry.setPet(pet);
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+
+        DiaryEntry diaryEntry = diaryRepository
+                .findByPet_PetIdAndEntryDate(pet.getPetId(), today)
+                .orElseGet(() -> {
+                    DiaryEntry newDiaryEntry = new DiaryEntry();
+                    newDiaryEntry.setPet(pet);
+                    newDiaryEntry.setEntryDate(today);
+                    newDiaryEntry.setMemo(null);
+                    return newDiaryEntry;
+                });
+
         diaryEntry.setDiagnosis(diagnosis);
-        diaryEntry.setEntryDate(LocalDate.now(SEOUL_ZONE));
-        diaryEntry.setMemo(null);
 
         diaryRepository.save(diaryEntry);
     }

--- a/src/main/java/com/ppopi/ppopihouse/diary/domain/DiaryEntry.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/domain/DiaryEntry.java
@@ -33,4 +33,8 @@ public class DiaryEntry {
     private LocalDate entryDate;
 
     private String memo;
+
+    public void updateDiagnosis(Diagnosis diagnosis) {
+        this.diagnosis = diagnosis;
+    }
 }

--- a/src/main/java/com/ppopi/ppopihouse/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/repository/DiaryRepository.java
@@ -5,6 +5,7 @@ import com.ppopi.ppopihouse.pet.domain.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntry, Long> {
     // 특정 펫 리스트의 기간 내 다이어리 조회
@@ -12,4 +13,6 @@ public interface DiaryRepository extends JpaRepository<DiaryEntry, Long> {
 
     // 일별 조회를 위한 메서드 추가
     List<DiaryEntry> findAllByPetInAndEntryDate(List<Pet> pets, LocalDate entryDate);
+
+    Optional<DiaryEntry> findByPet_PetIdAndEntryDate(Long petId, LocalDate entryDate);
 }

--- a/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
+++ b/src/main/java/com/ppopi/ppopihouse/diary/service/DiaryService.java
@@ -35,7 +35,7 @@ public class DiaryService {
      * 월별 다이어리 기록 조회
      */
     public DiaryResponseDto.MonthlyResponse findMonthlyRecords(Long memberId, int year, int month) {
-        List<Pet> myPets = petRepository.findAllByMember_MemberId(memberId);
+        List<Pet> myPets = petRepository.findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(memberId);
 
         LocalDate start = YearMonth.of(year, month).atDay(1);
         LocalDate end = YearMonth.of(year, month).atEndOfMonth();
@@ -66,7 +66,7 @@ public class DiaryService {
      */
     public List<DiaryResponseDto.DayDetailResponse> findDailyDiaries(Long memberId, int year, int month, int day) {
         LocalDate targetDate = LocalDate.of(year, month, day);
-        List<Pet> myPets = petRepository.findAllByMember_MemberId(memberId);
+        List<Pet> myPets = petRepository.findAllByMember_MemberIdAndDeletedFalseOrderByPetIdAsc(memberId);
         List<DiaryEntry> entries = diaryRepository.findAllByPetInAndEntryDate(myPets, targetDate);
 
         return entries.stream().map(entry -> {

--- a/src/main/java/com/ppopi/ppopihouse/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ppopi/ppopihouse/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,10 @@ package com.ppopi.ppopihouse.global.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -12,6 +16,8 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.reactive.resource.NoResourceFoundException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.NoSuchElementException;
 
@@ -102,6 +108,22 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse("UNAUTHORIZED", e.getMessage()));
     }
 
+    // 401: 인증 정보 없음 / 인증 실패
+    @ExceptionHandler({
+            AuthenticationException.class,
+            AuthenticationCredentialsNotFoundException.class
+    })
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(
+            Exception e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(
+                        "UNAUTHORIZED",
+                        "인증 정보가 없거나 유효하지 않습니다."
+                ));
+    }
+
     // 403: 인증은 됐지만 권한 없음
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(
@@ -122,6 +144,22 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse("NOT_FOUND", e.getMessage()));
     }
 
+    // 404: 존재하지 않는 URL
+    @ExceptionHandler({
+            NoHandlerFoundException.class,
+            NoResourceFoundException.class
+    })
+    public ResponseEntity<ErrorResponse> handleNotFoundException(
+            Exception e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(
+                        "NOT_FOUND",
+                        "요청한 URL을 찾을 수 없습니다."
+                ));
+    }
+
     // 405: 지원하지 않는 HTTP Method
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
@@ -135,6 +173,19 @@ public class GlobalExceptionHandler {
                 ));
     }
 
+    // 406: 응답 가능한 Content-Type 없음
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotAcceptableException(
+            HttpMediaTypeNotAcceptableException e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_ACCEPTABLE)
+                .body(new ErrorResponse(
+                        "NOT_ACCEPTABLE",
+                        "요청한 응답 형식을 제공할 수 없습니다."
+                ));
+    }
+
     // 413: 업로드 파일 크기 초과
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(
@@ -145,6 +196,19 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(
                         "PAYLOAD_TOO_LARGE",
                         "업로드 가능한 파일 크기를 초과했습니다."
+                ));
+    }
+
+    // 415: 지원하지 않는 Content-Type
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException e
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                .body(new ErrorResponse(
+                        "UNSUPPORTED_MEDIA_TYPE",
+                        "지원하지 않는 요청 형식입니다."
                 ));
     }
 

--- a/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
+++ b/src/main/java/com/ppopi/ppopihouse/pet/repository/PetRepository.java
@@ -10,8 +10,6 @@ import java.util.Optional;
 public interface PetRepository extends JpaRepository<Pet, Long> {
     long countByMember_MemberIdAndDeletedFalse(Long memberId);
 
-    List<Pet> findAllByMember_MemberId(Long memberId);
-
     boolean existsByMemberAndDeletedFalse(Member member);
 
     List<Pet> findAllByMemberAndDeletedFalseOrderByPetIdAsc(Member member);


### PR DESCRIPTION
## 📝 작업 내용

* 체크리스트 응답 방식을 DB 조회 기반에서 enum 기반 반환 구조로 수정
* 동일 날짜에 여러 번 진단 시 기존 다이어리를 최신 진단 결과로 업데이트하도록 수정
* 삭제된 반려동물이 다이어리 조회 결과에 포함되지 않도록 수정
* 공통 예외 처리 세분화

---

## 🔥 변경 사항

### 체크리스트 응답 구조 수정

* 기존 DB 접근 기반 체크리스트 반환 로직 수정
* enum 값을 기준으로 체크리스트 목록을 반환하도록 변경
* 불필요한 DB 의존도 감소

### 동일 날짜 진단 시 다이어리 업데이트 처리

* 기존에는 동일 날짜에 진단을 여러 번 수행하면 다이어리가 중복 생성됨
* `petId + entryDate` 기준으로 기존 다이어리를 조회하도록 수정
* 기존 다이어리가 있으면 최신 `Diagnosis`로 업데이트
* 기존 다이어리가 없을 때만 새 다이어리 생성

### 삭제된 반려동물 다이어리 조회 제외

* soft delete된 반려동물이 다이어리 조회 결과에 포함되는 문제 수정
* 다이어리 조회 시 `deleted=false`인 반려동물만 기준으로 조회하도록 변경

### 공통 예외 처리 개선

* 자주 발생하는 예외 코드에 대한 핸들러 추가
* 유효하지 않은 URL 요청 시 500이 아닌 404 응답이 반환되도록 수정
* 인증/요청 형식/지원하지 않는 미디어 타입 등 예외 처리 세분화

---

## ✅ 체크리스트

* [x] 체크리스트 enum 기반 반환 확인
* [x] 동일 날짜 진단 시 다이어리 중복 생성 방지 확인
* [x] 최신 진단 결과로 기존 다이어리 업데이트 확인
* [x] 삭제된 반려동물 다이어리 조회 제외 확인
* [x] 유효하지 않은 URL 요청 시 404 반환 확인
* [x] 로컬 빌드 확인
* [ ] Swagger 테스트 완료

---

## 🔗 관련 이슈

Closes #75 

---

## 💬 기타 참고사항

* 다이어리는 `petId + entryDate` 기준으로 하루 1개만 유지되도록 수정했습니다.
* soft delete 구조에 맞춰 다이어리 조회 조건을 정리했습니다.
* 공통 예외 처리에서 catch-all `Exception.class`로 404 계열 예외가 500 처리되지 않도록 개선했습니다.
