### PR TITLE
FIX: 병원 상세 조회 시 조회 실패 문제 개선

### DIFF
--- a/src/main/java/com/ppopi/ppopihouse/hospital/cache/HospitalCacheService.java
+++ b/src/main/java/com/ppopi/ppopihouse/hospital/cache/HospitalCacheService.java
@@ -1,0 +1,36 @@
+package com.ppopi.ppopihouse.hospital.cache;
+
+import com.ppopi.ppopihouse.hospital.external.kakao.KakaoPlaceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class HospitalCacheService {
+
+    private static final String KEY_PREFIX = "hospital:place:";
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void save(KakaoPlaceResponse.Document document) {
+        redisTemplate.opsForValue().set(
+                KEY_PREFIX + document.id(),
+                document,
+                TTL
+        );
+    }
+
+    public KakaoPlaceResponse.Document get(String hospitalId) {
+        Object value = redisTemplate.opsForValue().get(KEY_PREFIX + hospitalId);
+
+        if (value == null) {
+            return null;
+        }
+
+        return (KakaoPlaceResponse.Document) value;
+    }
+}

--- a/src/main/java/com/ppopi/ppopihouse/hospital/cache/HospitalCacheService.java
+++ b/src/main/java/com/ppopi/ppopihouse/hospital/cache/HospitalCacheService.java
@@ -1,8 +1,10 @@
 package com.ppopi.ppopihouse.hospital.cache;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ppopi.ppopihouse.hospital.external.kakao.KakaoPlaceResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -14,23 +16,34 @@ public class HospitalCacheService {
     private static final String KEY_PREFIX = "hospital:place:";
     private static final Duration TTL = Duration.ofMinutes(30);
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
 
     public void save(KakaoPlaceResponse.Document document) {
-        redisTemplate.opsForValue().set(
-                KEY_PREFIX + document.id(),
-                document,
-                TTL
-        );
+        try {
+            String json = objectMapper.writeValueAsString(document);
+
+            stringRedisTemplate.opsForValue().set(
+                    KEY_PREFIX + document.id(),
+                    json,
+                    TTL
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("병원 정보를 캐시에 저장하는 중 오류가 발생했습니다.", e);
+        }
     }
 
     public KakaoPlaceResponse.Document get(String hospitalId) {
-        Object value = redisTemplate.opsForValue().get(KEY_PREFIX + hospitalId);
+        String json = stringRedisTemplate.opsForValue().get(KEY_PREFIX + hospitalId);
 
-        if (value == null) {
+        if (json == null) {
             return null;
         }
 
-        return (KakaoPlaceResponse.Document) value;
+        try {
+            return objectMapper.readValue(json, KakaoPlaceResponse.Document.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("병원 정보를 캐시에서 읽는 중 오류가 발생했습니다.", e);
+        }
     }
 }

--- a/src/main/java/com/ppopi/ppopihouse/hospital/service/HospitalServiceImpl.java
+++ b/src/main/java/com/ppopi/ppopihouse/hospital/service/HospitalServiceImpl.java
@@ -6,8 +6,10 @@ import com.ppopi.ppopihouse.hospital.dto.response.HospitalListResponse;
 import com.ppopi.ppopihouse.hospital.external.google.GooglePlacesClient;
 import com.ppopi.ppopihouse.hospital.external.kakao.KakaoLocalClient;
 import com.ppopi.ppopihouse.hospital.external.kakao.KakaoPlaceResponse;
+import com.ppopi.ppopihouse.hospital.cache.HospitalCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 
 import com.ppopi.ppopihouse.hospital.external.google.GooglePlaceResponse;
 
@@ -24,6 +26,7 @@ public class HospitalServiceImpl implements HospitalService {
     private static final int DEFAULT_LIMIT = 15;
     private final GooglePlacesClient googlePlacesClient;
     private final KakaoLocalClient kakaoLocalClient;
+    private final HospitalCacheService hospitalCacheService;
 
     @Override
     public List<HospitalListResponse> getHospitals(HospitalSearchRequest request) {
@@ -37,6 +40,8 @@ public class HospitalServiceImpl implements HospitalService {
                 .stream()
                 .filter(kakaoPlace -> isInBounds(kakaoPlace, request))
                 .map(kakaoPlace -> {
+                    hospitalCacheService.save(kakaoPlace);
+                    
                     double hospitalLat = Double.parseDouble(kakaoPlace.y());
                     double hospitalLng = Double.parseDouble(kakaoPlace.x());
 
@@ -67,12 +72,11 @@ public class HospitalServiceImpl implements HospitalService {
 
     @Override
     public HospitalDetailResponse getHospital(String hospitalId, double centerLat, double centerLng) {
-        KakaoPlaceResponse.Document kakaoPlace = kakaoLocalClient
-                .searchAnimalHospitals(centerLat, centerLng, DEFAULT_LIMIT)
-                .stream()
-                .filter(place -> hospitalId.equals(place.id()))
-                .findFirst()
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 병원입니다."));
+        KakaoPlaceResponse.Document kakaoPlace = hospitalCacheService.get(hospitalId);
+
+        if (kakaoPlace == null) {
+            throw new NoSuchElementException("병원 정보가 만료되었습니다. 병원 목록을 다시 조회해 주세요.");
+        }
 
         double hospitalLat = Double.parseDouble(kakaoPlace.y());
         double hospitalLng = Double.parseDouble(kakaoPlace.x());


### PR DESCRIPTION
## 📝 작업 내용

* 병원 상세 조회 시 병원 ID로 조회되지 않는 문제 분석
* 현재 위치 기반 병원 재검색 방식의 한계 확인
* Redis 캐시를 활용한 병원 정보 조회 구조 도입

---

## 🔥 변경 사항

* 병원 목록 조회 결과를 Redis에 캐싱하도록 구현
* 병원 상세 조회 시 Redis에 저장된 병원 정보를 조회하도록 수정
* 사용자 위치(centerLat, centerLng)는 거리 계산 용도로만 사용하도록 구조 개선

---

## ✅ 체크리스트

* [ ] 기능 정상 동작 확인
* [ ] 로컬 테스트 완료
* [ ] Swagger 테스트 완료
* [ ] 코드 리뷰 반영 완료

---

## 💬 기타 참고사항

* 기존에는 사용자 현재 위치 기준으로 병원을 재검색한 뒤 병원 ID를 찾는 방식이어서, 검색 범위를 벗어난 병원은 상세 조회에 실패하는 문제가 발생
* Redis 캐시를 활용하여 병원 ID 기반 상세 조회가 가능하도록 개선함
